### PR TITLE
fix: getGrantedPermissions ts return type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,7 +88,7 @@ export function requestPermission(
   return HealthConnect.requestPermission(permissions, providerPackageName);
 }
 
-export function getGrantedPermissions(): Promise<Permission> {
+export function getGrantedPermissions(): Promise<Permission[]> {
   return HealthConnect.getGrantedPermissions();
 }
 


### PR DESCRIPTION
Small fix for `getGrantedPermissions` method return type