### PR TITLE
fix(types): request permission return type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,7 +84,7 @@ export function openHealthConnectSettings(): void {
 export function requestPermission(
   permissions: Permission[],
   providerPackageName = DEFAULT_PROVIDER_PACKAGE_NAME
-): Promise<Permission> {
+): Promise<Permission[]> {
   return HealthConnect.requestPermission(permissions, providerPackageName);
 }
 


### PR DESCRIPTION
Request permission method is returning single object instead of an array of granted permissions.