### PR TITLE
fix: Mapping between kilocalories and kilojoules

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -287,8 +287,8 @@ fun getEnergyFromJsMap(energyMap: ReadableMap?): Energy {
 
   val value = energyMap.getDouble("value")
   return when (energyMap.getString("unit")) {
-    "kilojoules" -> Energy.kilocalories(value)
-    "kilocalories" -> Energy.kilojoules(value)
+    "kilojoules" -> Energy.kilojoules(value)
+    "kilocalories" -> Energy.kilocalories(value)
     "joules" -> Energy.joules(value)
     "calories" -> Energy.calories(value)
     else -> Energy.calories(value)


### PR DESCRIPTION
Due to a bug (probably a typo), kilocalories were being mapped to kilojoules when converting from ReactHealthRecord to HealthConnectRecord.