### PR TITLE
fix: lib crashing when proguard is enabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,7 @@ android {
     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+    consumerProguardFiles "proguard-rules.pro"
   }
   buildTypes {
     release {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class dev.matinzd.healthconnect.records.** { *; }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -54,7 +54,7 @@ react {
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,9 +59,13 @@ export default function App() {
         startTime: getLastWeekDate().toISOString(),
         endTime: getTodayDate().toISOString(),
       },
-    ]).then((ids) => {
-      console.log('Records inserted ', { ids });
-    });
+    ])
+      .then((ids) => {
+        console.log('Records inserted ', { ids });
+      })
+      .catch((err) => {
+        console.error('Error inserting records ', { err });
+      });
   };
 
   const readSampleData = () => {
@@ -71,17 +75,23 @@ export default function App() {
         startTime: getLastTwoWeeksDate().toISOString(),
         endTime: getTodayDate().toISOString(),
       },
-    }).then((result) => {
-      console.log('Retrieved records: ', JSON.stringify({ result }, null, 2));
-    });
+    })
+      .then((result) => {
+        console.log('Retrieved records: ', JSON.stringify({ result }, null, 2));
+      })
+      .catch((err) => {
+        console.error('Error reading records ', { err });
+      });
   };
 
   const readSampleDataSingle = () => {
-    readRecord('Steps', 'a7bdea65-86ce-4eb2-a9ef-a87e6a7d9df2').then(
-      (result) => {
+    readRecord('Steps', 'a7bdea65-86ce-4eb2-a9ef-a87e6a7d9df2')
+      .then((result) => {
         console.log('Retrieved record: ', JSON.stringify({ result }, null, 2));
-      }
-    );
+      })
+      .catch((err) => {
+        console.error('Error reading record ', { err });
+      });
   };
 
   const aggregateSampleData = () => {


### PR DESCRIPTION
## Rationale

Given that we dynamically assign record classes during runtime based on activity types, proguard will strip down all those classes during compile time and it will lead the apps that have proguard enabled to crash. 

https://github.com/matinzd/react-native-health-connect/blob/main/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt#L22-L37

Fixes https://github.com/matinzd/react-native-health-connect/issues/89
