### PR TITLE
chore: Update README for clarity on Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 This library is a wrapper around Health Connect for react native. Health Connect is an Android API and platform. It unifies data from multiple devices and apps into an ecosystem. For Android developers, it provides a single interface for reading and writing a user’s health and fitness data. For Android users, it offers a place for control over which apps have read and/or write access to different types of data. Health Connect also provides on-device storage. Read more [here](https://developer.android.com/guide/health-and-fitness/health-connect).
 
 ## Requirements
+Make sure you have React Native version 0.71 or higher installed to use v2 of React Native Health Connect.
 
 - [Health Connect](https://play.google.com/store/apps/details?id=com.google.android.apps.healthdata&hl=en&gl=US) needs to be installed on the user's device. Starting from Android 14 (Upside Down Cake), Health Connect is part of the Android Framework. Read more [here](https://developer.android.com/health-and-fitness/guides/health-connect/develop/get-started#step-1).
 - Health Connect API requires `minSdkVersion=26` (Android Oreo / 8.0).


### PR DESCRIPTION
It should specify the requirement that React Native version 0.71 or higher is required.
This was not specified anywhere except the [Releases](https://github.com/matinzd/react-native-health-connect/releases/tag/v2.0.0) page.
Otherwise the app crashes for people using React Native version below 0.71 when they call the `requestPermission` function
