### PR TITLE
fix: add missing support to ElevationGained aggregation

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
@@ -32,10 +32,19 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
   }
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
-    throw AggregationNotSupported()
+    return AggregateRequest(
+      metrics = setOf(
+        ElevationGainedRecord.ELEVATION_GAINED_TOTAL
+      ),
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
-    throw AggregationNotSupported()
+    return WritableNativeMap().apply {
+      putMap("ELEVATION_GAINED_TOTAL", lengthToJsMap(record[ElevationGainedRecord.ELEVATION_GAINED_TOTAL]))
+      putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
   }
 }

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -175,6 +175,11 @@ interface PowerAggregateResult extends BaseAggregate {
   POWER_MAX: PowerResult;
 }
 
+interface ElevationGainedAggregateResult extends BaseAggregate {
+  recordType: 'ElevationGained';
+  ELEVATION_GAINED_TOTAL: LengthResult;
+}
+
 export type AggregateRecordResult =
   | ActiveCaloriesBurnedAggregateResult
   | BasalMetabolicRateAggregateResult
@@ -195,7 +200,8 @@ export type AggregateRecordResult =
   | WheelchairPushesAggregateResult
   | StepsCadenceAggregateResult
   | TotalCaloriesBurnedAggregateResult
-  | PowerAggregateResult;
+  | PowerAggregateResult
+  | ElevationGainedAggregateResult;
 
 export type AggregateResultRecordType = AggregateRecordResult['recordType'];
 


### PR DESCRIPTION
This add support to ElevationGained aggregation.

Currently an exception is thrown when trying to perform aggregation with ElevationGained. However, Health Connect supports aggregation of this data type.

```json
{
  "result": {
    "ELEVATION_GAINED_TOTAL": {
      "inFeet": 75.45931758530183,
      "inInches": 905.511811023622,
      "inKilometers": 0.023,
      "inMeters": 23,
      "inMiles": 0.014291572942945556
    },
    "dataOrigins": [
      "androidx.health.connect.client.devtool"
    ]
  }
}
```