### PR TITLE
fix: fixes incorrectly mapping from granted permissions to record types 

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.InvalidRecordType
 import dev.matinzd.healthconnect.utils.UnsupportedPermissionType
 import dev.matinzd.healthconnect.utils.reactRecordTypeToClassMap
-import java.util.logging.Logger
 
 class PermissionUtils {
   companion object {
@@ -42,23 +41,22 @@ class PermissionUtils {
             map.putString("recordType", recordType)
             map.putString("accessType", accessType)
             pushMap(map)
-          }
-          catch (e: UnsupportedPermissionType) {
+          } catch (e: UnsupportedPermissionType) {
             Log.d("Unsupported Permission", "Encountered an unsupported permission type: $it")
           }
         }
       }
     }
 
-    private fun extractPermissionResult(permissionName: String): Pair<String, String>  {
-      for((recordType, recordClass) in reactRecordTypeToClassMap) {
-          val readPermissionForRecord = HealthPermission.getReadPermission(recordClass)
-          if(readPermissionForRecord == permissionName) {
-            return Pair("read", recordType)
-          }
+    private fun extractPermissionResult(permissionName: String): Pair<String, String> {
+      for ((recordType, recordClass) in reactRecordTypeToClassMap) {
+        val readPermissionForRecord = HealthPermission.getReadPermission(recordClass)
+        if (readPermissionForRecord == permissionName) {
+          return Pair("read", recordType)
+        }
 
         val writePermissionForRecord = HealthPermission.getWritePermission(recordClass)
-        if(writePermissionForRecord == permissionName) {
+        if (writePermissionForRecord == permissionName) {
           return Pair("write", recordType)
         }
       }

--- a/android/src/main/java/dev/matinzd/healthconnect/permissions/ReactPermission.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/permissions/ReactPermission.kt
@@ -1,0 +1,23 @@
+package dev.matinzd.healthconnect.permissions
+
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeMap
+
+data class ReactPermission(val accessType: AccessType, val recordType: String) {
+  fun toReadableMap(): ReadableMap {
+    val map = WritableNativeMap()
+    map.putString(ACCESS_TYPE, accessType.reactName)
+    map.putString(RECORD_TYPE, recordType)
+    return map
+  }
+
+  companion object {
+    private const val ACCESS_TYPE = "accessType"
+    private const val RECORD_TYPE = "recordType"
+  }
+}
+
+enum class AccessType(val reactName: String) {
+  READ("read"),
+  WRITE("write")
+}

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
@@ -15,7 +15,6 @@ class InvalidBloodPressure : Exception("Blood pressure is not valid")
 class InvalidMass : Exception("Mass is not valid")
 class InvalidLength : Exception("Length is not valid")
 class AggregationNotSupported : Exception("Aggregation is not supported for this record")
-class UnsupportedPermissionType : Exception()
 
 fun Promise.rejectWithException(exception: Exception) {
   val code = when (exception) {

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
@@ -15,6 +15,7 @@ class InvalidBloodPressure : Exception("Blood pressure is not valid")
 class InvalidMass : Exception("Mass is not valid")
 class InvalidLength : Exception("Length is not valid")
 class AggregationNotSupported : Exception("Aggregation is not supported for this record")
+class UnsupportedPermissionType : Exception()
 
 fun Promise.rejectWithException(exception: Exception) {
   val code = when (exception) {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.WRITE_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_EXERCISE"/>
+    <uses-permission android:name="android.permission.health.WRITE_EXERCISE"/>
 
     <application
       android:name=".MainApplication"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -133,6 +133,14 @@ export default function App() {
         accessType: 'write',
         recordType: 'Steps',
       },
+      {
+        accessType: 'write',
+        recordType: 'ExerciseSession',
+      },
+      {
+        accessType: 'read',
+        recordType: 'ExerciseSession',
+      },
     ]).then((permissions) => {
       console.log('Granted permissions on request ', { permissions });
     });


### PR DESCRIPTION
Rebase of https://github.com/matinzd/react-native-health-connect/pull/142

## Summary
How we infer Record types from permission names after calling [`PermissionController.getGrantedPermissions`](https://developer.android.com/reference/androidx/health/connect/client/PermissionController#getGrantedPermissions()) doesn't work for all permissions - not all record names overlap with snake cased version of the permission names. For example, the code block:
```kotlin
val perm1 = HealthPermission.getReadPermission(MenstruationFlowRecord::class)
      val perm2 = HealthPermission.getReadPermission(MenstruationPeriodRecord::class)
      val perm3 = HealthPermission.getReadPermission(ExerciseSessionRecord::class)
      listOf(perm1, perm2, perm3).forEach {
        Log.d("PermissionUtils", it)
      }
```
will output:
```
2024-08-31 14:00:59.844 21940-22030 PermissionUtils         com.healthconnectexample             D  android.permission.health.READ_MENSTRUATION
2024-08-31 14:00:59.844 21940-22030 PermissionUtils         com.healthconnectexample             D  android.permission.health.READ_MENSTRUATION
2024-08-31 14:00:59.844 21940-22030 PermissionUtils         com.healthconnectexample             D  android.permission.health.READ_EXERCISE
```

The only way to extract the exact set of React RecordTypes an app has permissions for would be to run through the record classes supported by the library and run its read/write permission against the list of granted permissions returned by the PermissionController which is what this PR aims to do.

## Testing
Manually tested the example app and the granted permissions worked as usual.

## Related Issues
Should fix #63 as the record name for sleep is `SleepSession` ([ref](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/package-summary)) while the permission name is `READ_/WRITE_SLEEP` ([ref](https://developer.android.com/reference/android/health/connect/HealthPermissions#READ_SLEEP)).