### PR TITLE
feat: add aggregateGroupByPeriod API

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -148,6 +148,24 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
     }
   }
 
+  fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise) {
+    throwUnlessClientIsAvailable(promise) {
+      coroutineScope.launch {
+        try {
+          val recordType = record.getString("recordType") ?: ""
+          val response = healthConnectClient.aggregateGroupByPeriod(
+            ReactHealthRecord.getAggregateGroupByPeriodRequest(
+              recordType, record
+            )
+          )
+          promise.resolve(ReactHealthRecord.parseAggregationResultGroupedByPeriod(recordType, response))
+        } catch (e: Exception) {
+          promise.rejectWithException(e)
+        }
+      }
+    }
+  }
+
   fun getChanges(options: ReadableMap, promise: Promise) {
     throwUnlessClientIsAvailable(promise) {
       coroutineScope.launch {

--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
@@ -71,6 +71,11 @@ class HealthConnectModule internal constructor(context: ReactApplicationContext)
   }
 
   @ReactMethod
+  override fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise) {
+    return manager.aggregateGroupByPeriod(record, promise)
+  }
+
+  @ReactMethod
   override fun getChanges(options: ReadableMap, promise: Promise) {
     return manager.getChanges(options, promise)
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
@@ -1,11 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.bridge.WritableNativeArray
 import dev.matinzd.healthconnect.utils.convertDataOriginsToJsArray
 import dev.matinzd.healthconnect.utils.convertJsToDataOriginSet
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -14,9 +17,12 @@ import dev.matinzd.healthconnect.utils.energyToJsMap
 import dev.matinzd.healthconnect.utils.getEnergyFromJsMap
 import dev.matinzd.healthconnect.utils.getTimeRangeFilter
 import dev.matinzd.healthconnect.utils.toMapList
+import dev.matinzd.healthconnect.utils.mapPeriodStringToPeriod
 import java.time.Instant
 
 class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurnedRecord> {
+  private val aggregateMetrics = setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<ActiveCaloriesBurnedRecord> {
     return records.toMapList().map {
       ActiveCaloriesBurnedRecord(
@@ -41,8 +47,17 @@ class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurn
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -69,6 +84,19 @@ class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurn
       }
       putMap("ACTIVE_CALORIES_TOTAL", map)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
@@ -17,7 +17,7 @@ import dev.matinzd.healthconnect.utils.energyToJsMap
 import dev.matinzd.healthconnect.utils.getEnergyFromJsMap
 import dev.matinzd.healthconnect.utils.getTimeRangeFilter
 import dev.matinzd.healthconnect.utils.toMapList
-import dev.matinzd.healthconnect.utils.mapPeriodStringToPeriod
+import dev.matinzd.healthconnect.utils.mapJsPeriodToPeriod
 import java.time.Instant
 
 class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurnedRecord> {
@@ -57,7 +57,7 @@ class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurn
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalBodyTemperatureRecord.kt
@@ -1,12 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BasalBodyTemperatureRecord
 import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.InvalidTemperature
@@ -45,7 +48,15 @@ class ReactBasalBodyTemperatureRecord : ReactHealthRecordImpl<BasalBodyTemperatu
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
@@ -1,11 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BasalMetabolicRateRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Power
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.InvalidPower
 import dev.matinzd.healthconnect.utils.convertDataOriginsToJsArray
@@ -13,10 +16,13 @@ import dev.matinzd.healthconnect.utils.convertJsToDataOriginSet
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
 import dev.matinzd.healthconnect.utils.getTimeRangeFilter
+import dev.matinzd.healthconnect.utils.mapPeriodStringToPeriod
 import dev.matinzd.healthconnect.utils.toMapList
 import java.time.Instant
 
 class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRecord> {
+  private val aggregateMetrics = setOf(BasalMetabolicRateRecord.BASAL_CALORIES_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<BasalMetabolicRateRecord> {
     return records.toMapList().map {
       BasalMetabolicRateRecord(
@@ -38,10 +44,32 @@ class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRe
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(BasalMetabolicRateRecord.BASAL_CALORIES_TOTAL),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
+    }
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
@@ -16,7 +16,7 @@ import dev.matinzd.healthconnect.utils.convertJsToDataOriginSet
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
 import dev.matinzd.healthconnect.utils.getTimeRangeFilter
-import dev.matinzd.healthconnect.utils.mapPeriodStringToPeriod
+import dev.matinzd.healthconnect.utils.mapJsPeriodToPeriod
 import dev.matinzd.healthconnect.utils.toMapList
 import java.time.Instant
 
@@ -54,7 +54,7 @@ class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRe
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodGlucoseRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodGlucoseRecord.kt
@@ -1,12 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BloodGlucoseRecord
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_UNKNOWN
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.BloodGlucose
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.InvalidBloodGlucoseLevel
@@ -50,7 +53,15 @@ class ReactBloodGlucoseRecord : ReactHealthRecordImpl<BloodGlucoseRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -62,7 +62,7 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -1,16 +1,28 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BloodPressureRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Pressure
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
+  private val aggregateMetrics = setOf(
+    BloodPressureRecord.SYSTOLIC_AVG,
+    BloodPressureRecord.SYSTOLIC_MIN,
+    BloodPressureRecord.SYSTOLIC_MAX,
+    BloodPressureRecord.DIASTOLIC_AVG,
+    BloodPressureRecord.DIASTOLIC_MIN,
+    BloodPressureRecord.DIASTOLIC_MAX
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<BloodPressureRecord> {
     return records.toMapList().map {
       BloodPressureRecord(
@@ -40,15 +52,17 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        BloodPressureRecord.SYSTOLIC_AVG,
-        BloodPressureRecord.SYSTOLIC_MIN,
-        BloodPressureRecord.SYSTOLIC_MAX,
-        BloodPressureRecord.DIASTOLIC_AVG,
-        BloodPressureRecord.DIASTOLIC_MIN,
-        BloodPressureRecord.DIASTOLIC_MAX
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -77,6 +91,19 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
         getPressureMap(record[BloodPressureRecord.DIASTOLIC_MAX]?.inMillimetersOfMercury ?: 0.0)
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyFatRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyFatRecord.kt
@@ -1,11 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyFatRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Percentage
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -34,6 +37,14 @@ class ReactBodyFatRecord : ReactHealthRecordImpl<BodyFatRecord> {
   }
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -1,12 +1,15 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
 import androidx.health.connect.client.records.BodyTemperatureRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.InvalidTemperature
@@ -45,7 +48,15 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyWaterMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyWaterMassRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyWaterMassRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
@@ -33,7 +36,15 @@ class ReactBodyWaterMassRecord : ReactHealthRecordImpl<BodyWaterMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBoneMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBoneMassRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BoneMassRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -38,7 +41,15 @@ class ReactBoneMassRecord : ReactHealthRecordImpl<BoneMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCervicalMucusRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCervicalMucusRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -39,7 +42,15 @@ class ReactCervicalMucusRecord : ReactHealthRecordImpl<CervicalMucusRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,12 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingCadenceRecord> {
+  private val aggregateMetrics = setOf(
+    CyclingPedalingCadenceRecord.RPM_AVG,
+    CyclingPedalingCadenceRecord.RPM_MAX,
+    CyclingPedalingCadenceRecord.RPM_MIN
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<CyclingPedalingCadenceRecord> {
     return records.toMapList().map { map ->
       CyclingPedalingCadenceRecord(
@@ -48,12 +56,17 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        CyclingPedalingCadenceRecord.RPM_AVG,
-        CyclingPedalingCadenceRecord.RPM_MAX,
-        CyclingPedalingCadenceRecord.RPM_MIN
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -64,6 +77,19 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
       putDouble("RPM_MAX", record[CyclingPedalingCadenceRecord.RPM_MAX] ?: 0.0)
       putDouble("RPM_MIN", record[CyclingPedalingCadenceRecord.RPM_MIN] ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
@@ -66,7 +66,7 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
@@ -1,15 +1,22 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
+  private val aggregateMetrics = setOf(
+    DistanceRecord.DISTANCE_TOTAL,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<DistanceRecord> {
     return records.toMapList().map { map ->
       DistanceRecord(
@@ -23,7 +30,6 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
     }
   }
 
-
   override fun parseRecord(record: DistanceRecord): WritableNativeMap {
     return WritableNativeMap().apply {
       putString("startTime", record.startTime.toString())
@@ -35,10 +41,17 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        DistanceRecord.DISTANCE_TOTAL,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -47,6 +60,19 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
     return WritableNativeMap().apply {
       putMap("DISTANCE", lengthToJsMap(record[DistanceRecord.DISTANCE_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
@@ -51,7 +51,7 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
@@ -49,7 +49,7 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.ElevationGainedRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> {
+  private val aggregateMetrics = setOf(ElevationGainedRecord.ELEVATION_GAINED_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<ElevationGainedRecord> {
     return records.toMapList().map {
       ElevationGainedRecord(
@@ -34,10 +39,17 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        ElevationGainedRecord.ELEVATION_GAINED_TOTAL
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -46,6 +58,19 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
     return WritableNativeMap().apply {
       putMap("ELEVATION_GAINED_TOTAL", lengthToJsMap(record[ElevationGainedRecord.ELEVATION_GAINED_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -148,7 +148,7 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.FloorsClimbedRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
+  private val aggregateMetrics = setOf(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<FloorsClimbedRecord> {
     return records.toMapList().map {
       FloorsClimbedRecord(
@@ -34,8 +39,17 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -44,6 +58,19 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
     return WritableNativeMap().apply {
       putDouble("FLOORS_CLIMBED_TOTAL", record[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL] ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
@@ -49,7 +49,7 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.response.InsertRecordsResponse
 import androidx.health.connect.client.response.ReadRecordResponse
@@ -71,10 +73,22 @@ class ReactHealthRecord {
       return recordClass.getAggregateRequest(reactRequest)
     }
 
+    fun getAggregateGroupByPeriodRequest(recordType: String, reactRequest: ReadableMap): AggregateGroupByPeriodRequest {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.getAggregateGroupByPeriodRequest(reactRequest)
+    }
+
     fun parseAggregationResult(recordType: String, result: AggregationResult): WritableNativeMap {
       val recordClass = createReactHealthRecordInstance<Record>(recordType)
 
       return recordClass.parseAggregationResult(result)
+    }
+
+    fun parseAggregationResultGroupedByPeriod(recordType: String, result: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.parseAggregationResultGroupedByPeriod(result)
     }
 
     fun parseRecords(

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.bridge.WritableNativeArray
 
 interface ReactHealthRecordImpl<T : Record> {
   fun parseWriteRecord(records: ReadableArray): List<T>
   fun parseRecord(record: T): WritableNativeMap
   fun getAggregateRequest(record: ReadableMap): AggregateRequest
+  fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
+  fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -67,7 +67,7 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -37,7 +40,15 @@ class ReactHeartRateVariabilityRmssdRecord :
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
@@ -1,15 +1,24 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeightRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
+  private val aggregateMetrics = setOf(
+    HeightRecord.HEIGHT_AVG,
+    HeightRecord.HEIGHT_MAX,
+    HeightRecord.HEIGHT_MIN,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<HeightRecord> {
     return records.toMapList().map { map ->
       HeightRecord(
@@ -31,12 +40,17 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        HeightRecord.HEIGHT_AVG,
-        HeightRecord.HEIGHT_MAX,
-        HeightRecord.HEIGHT_MIN,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -47,6 +61,19 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
       putMap("HEIGHT_MIN", lengthToJsMap(record[HeightRecord.HEIGHT_MIN]))
       putMap("HEIGHT_MAX", lengthToJsMap(record[HeightRecord.HEIGHT_MAX]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
@@ -50,7 +50,7 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
@@ -49,7 +49,7 @@ class ReactHydrationRecord : ReactHealthRecordImpl<HydrationRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactIntermenstrualBleedingRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactIntermenstrualBleedingRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.IntermenstrualBleedingRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -34,7 +37,15 @@ class ReactIntermenstrualBleedingRecord : ReactHealthRecordImpl<IntermenstrualBl
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactLeanBodyMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactLeanBodyMassRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.LeanBodyMassRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
@@ -33,7 +36,15 @@ class ReactLeanBodyMassRecord : ReactHealthRecordImpl<LeanBodyMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationFlowRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationFlowRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MenstruationFlowRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -37,7 +40,15 @@ class ReactMenstruationFlowRecord : ReactHealthRecordImpl<MenstruationFlowRecord
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationPeriodRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationPeriodRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MenstruationPeriodRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -37,7 +40,15 @@ class ReactMenstruationPeriodRecord : ReactHealthRecordImpl<MenstruationPeriodRe
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
@@ -177,7 +177,7 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
@@ -1,16 +1,62 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MealType
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
+  private val aggregateMetrics = setOf(
+    NutritionRecord.BIOTIN_TOTAL,
+    NutritionRecord.CAFFEINE_TOTAL,
+    NutritionRecord.CALCIUM_TOTAL,
+    NutritionRecord.ENERGY_TOTAL,
+    NutritionRecord.ENERGY_FROM_FAT_TOTAL,
+    NutritionRecord.CHLORIDE_TOTAL,
+    NutritionRecord.CHOLESTEROL_TOTAL,
+    NutritionRecord.CHROMIUM_TOTAL,
+    NutritionRecord.COPPER_TOTAL,
+    NutritionRecord.DIETARY_FIBER_TOTAL,
+    NutritionRecord.FOLATE_TOTAL,
+    NutritionRecord.FOLIC_ACID_TOTAL,
+    NutritionRecord.IODINE_TOTAL,
+    NutritionRecord.IRON_TOTAL,
+    NutritionRecord.MAGNESIUM_TOTAL,
+    NutritionRecord.MANGANESE_TOTAL,
+    NutritionRecord.MOLYBDENUM_TOTAL,
+    NutritionRecord.MONOUNSATURATED_FAT_TOTAL,
+    NutritionRecord.NIACIN_TOTAL,
+    NutritionRecord.PANTOTHENIC_ACID_TOTAL,
+    NutritionRecord.PHOSPHORUS_TOTAL,
+    NutritionRecord.POLYUNSATURATED_FAT_TOTAL,
+    NutritionRecord.POTASSIUM_TOTAL,
+    NutritionRecord.PROTEIN_TOTAL,
+    NutritionRecord.RIBOFLAVIN_TOTAL,
+    NutritionRecord.SATURATED_FAT_TOTAL,
+    NutritionRecord.SELENIUM_TOTAL,
+    NutritionRecord.SODIUM_TOTAL,
+    NutritionRecord.SUGAR_TOTAL,
+    NutritionRecord.THIAMIN_TOTAL,
+    NutritionRecord.TOTAL_CARBOHYDRATE_TOTAL,
+    NutritionRecord.TOTAL_FAT_TOTAL,
+    NutritionRecord.ZINC_TOTAL,
+    NutritionRecord.VITAMIN_A_TOTAL,
+    NutritionRecord.VITAMIN_B12_TOTAL,
+    NutritionRecord.VITAMIN_B6_TOTAL,
+    NutritionRecord.VITAMIN_C_TOTAL,
+    NutritionRecord.VITAMIN_D_TOTAL,
+    NutritionRecord.VITAMIN_E_TOTAL,
+    NutritionRecord.VITAMIN_K_TOTAL,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<NutritionRecord> {
     return records.toMapList().map { map ->
       NutritionRecord(
@@ -121,49 +167,17 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        NutritionRecord.BIOTIN_TOTAL,
-        NutritionRecord.CAFFEINE_TOTAL,
-        NutritionRecord.CALCIUM_TOTAL,
-        NutritionRecord.ENERGY_TOTAL,
-        NutritionRecord.ENERGY_FROM_FAT_TOTAL,
-        NutritionRecord.CHLORIDE_TOTAL,
-        NutritionRecord.CHOLESTEROL_TOTAL,
-        NutritionRecord.CHROMIUM_TOTAL,
-        NutritionRecord.COPPER_TOTAL,
-        NutritionRecord.DIETARY_FIBER_TOTAL,
-        NutritionRecord.FOLATE_TOTAL,
-        NutritionRecord.FOLIC_ACID_TOTAL,
-        NutritionRecord.IODINE_TOTAL,
-        NutritionRecord.IRON_TOTAL,
-        NutritionRecord.MAGNESIUM_TOTAL,
-        NutritionRecord.MANGANESE_TOTAL,
-        NutritionRecord.MOLYBDENUM_TOTAL,
-        NutritionRecord.MONOUNSATURATED_FAT_TOTAL,
-        NutritionRecord.NIACIN_TOTAL,
-        NutritionRecord.PANTOTHENIC_ACID_TOTAL,
-        NutritionRecord.PHOSPHORUS_TOTAL,
-        NutritionRecord.POLYUNSATURATED_FAT_TOTAL,
-        NutritionRecord.POTASSIUM_TOTAL,
-        NutritionRecord.PROTEIN_TOTAL,
-        NutritionRecord.RIBOFLAVIN_TOTAL,
-        NutritionRecord.SATURATED_FAT_TOTAL,
-        NutritionRecord.SELENIUM_TOTAL,
-        NutritionRecord.SODIUM_TOTAL,
-        NutritionRecord.SUGAR_TOTAL,
-        NutritionRecord.THIAMIN_TOTAL,
-        NutritionRecord.TOTAL_CARBOHYDRATE_TOTAL,
-        NutritionRecord.TOTAL_FAT_TOTAL,
-        NutritionRecord.ZINC_TOTAL,
-        NutritionRecord.VITAMIN_A_TOTAL,
-        NutritionRecord.VITAMIN_B12_TOTAL,
-        NutritionRecord.VITAMIN_B6_TOTAL,
-        NutritionRecord.VITAMIN_C_TOTAL,
-        NutritionRecord.VITAMIN_D_TOTAL,
-        NutritionRecord.VITAMIN_E_TOTAL,
-        NutritionRecord.VITAMIN_K_TOTAL,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -219,6 +233,19 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
       putMap("VITAMIN_E_TOTAL", massToJsMap(record[NutritionRecord.VITAMIN_E_TOTAL]))
       putMap("VITAMIN_K_TOTAL", massToJsMap(record[NutritionRecord.VITAMIN_K_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactOvulationTestRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactOvulationTestRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.OvulationTestRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -37,7 +40,15 @@ class ReactOvulationTestRecord : ReactHealthRecordImpl<OvulationTestRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactOxygenSaturationRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactOxygenSaturationRecord.kt
@@ -1,11 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.OxygenSaturationRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Percentage
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -37,7 +40,15 @@ class ReactOxygenSaturationRecord : ReactHealthRecordImpl<OxygenSaturationRecord
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
@@ -66,7 +66,7 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.PowerRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,12 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
+  private val aggregateMetrics = setOf(
+    PowerRecord.POWER_AVG,
+    PowerRecord.POWER_MAX,
+    PowerRecord.POWER_MIN,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<PowerRecord> {
     return records.toMapList().map { map ->
       PowerRecord(
@@ -48,12 +56,17 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        PowerRecord.POWER_AVG,
-        PowerRecord.POWER_MAX,
-        PowerRecord.POWER_MIN,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -64,6 +77,19 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
       putMap("POWER_MAX", powerToJsMap(record[PowerRecord.POWER_MAX]))
       putMap("POWER_MIN", powerToJsMap(record[PowerRecord.POWER_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRespiratoryRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRespiratoryRateRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.RespiratoryRateRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -34,7 +37,15 @@ class ReactRespiratoryRateRecord : ReactHealthRecordImpl<RespiratoryRateRecord> 
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -50,7 +50,7 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSexualActivityRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSexualActivityRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SexualActivityRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -36,7 +39,15 @@ class ReactSexualActivityRecord : ReactHealthRecordImpl<SexualActivityRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,8 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
+  private val aggregateMetrics = setOf(SleepSessionRecord.SLEEP_DURATION_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<SleepSessionRecord> {
     return records.toMapList().map { map ->
       SleepSessionRecord(
@@ -53,10 +57,17 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        SleepSessionRecord.SLEEP_DURATION_TOTAL
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -68,6 +79,19 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
         record[SleepSessionRecord.SLEEP_DURATION_TOTAL]?.seconds?.toDouble() ?: 0.0
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -67,7 +67,7 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
@@ -66,7 +66,7 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
@@ -1,7 +1,9 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SpeedRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -11,6 +13,12 @@ import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
+  private val aggregateMetrics = setOf(
+    SpeedRecord.SPEED_AVG,
+    SpeedRecord.SPEED_MIN,
+    SpeedRecord.SPEED_MAX,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<SpeedRecord> {
     return records.toMapList().map { map ->
       SpeedRecord(
@@ -48,12 +56,17 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        SpeedRecord.SPEED_AVG,
-        SpeedRecord.SPEED_MIN,
-        SpeedRecord.SPEED_MAX,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -64,6 +77,19 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
       putMap("SPEED_MAX", velocityToJsMap(record[SpeedRecord.SPEED_MAX]))
       putMap("SPEED_MIN", velocityToJsMap(record[SpeedRecord.SPEED_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
@@ -66,7 +66,7 @@ class ReactStepsCadenceRecord : ReactHealthRecordImpl<StepsCadenceRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -49,7 +49,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
+  private val aggregateMetrics = setOf(StepsRecord.COUNT_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<StepsRecord> {
     return records.toMapList().map { map ->
       StepsRecord(
@@ -34,10 +39,17 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        StepsRecord.COUNT_TOTAL
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -46,6 +58,19 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
     return WritableNativeMap().apply {
       putDouble("COUNT_TOTAL", record[StepsRecord.COUNT_TOTAL]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurnedRecord> {
+  private val aggregateMetrics = setOf(TotalCaloriesBurnedRecord.ENERGY_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<TotalCaloriesBurnedRecord> {
     return records.toMapList().map { map ->
       TotalCaloriesBurnedRecord(
@@ -34,10 +39,17 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        TotalCaloriesBurnedRecord.ENERGY_TOTAL
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -64,6 +76,19 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
       }
       putMap("ENERGY_TOTAL", map)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
@@ -49,7 +49,7 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
@@ -1,10 +1,13 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Vo2MaxRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.AggregationNotSupported
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
@@ -42,7 +45,15 @@ class ReactVo2MaxRecord : ReactHealthRecordImpl<Vo2MaxRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -50,7 +50,7 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -1,15 +1,24 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
+  private val aggregateMetrics = setOf(
+    WeightRecord.WEIGHT_AVG,
+    WeightRecord.WEIGHT_MAX,
+    WeightRecord.WEIGHT_MIN,
+  )
+
   override fun parseWriteRecord(records: ReadableArray): List<WeightRecord> {
     return records.toMapList().map { map ->
       WeightRecord(
@@ -31,12 +40,17 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        WeightRecord.WEIGHT_AVG,
-        WeightRecord.WEIGHT_MAX,
-        WeightRecord.WEIGHT_MIN,
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -47,6 +61,19 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
       putMap("WEIGHT_MAX", massToJsMap(record[WeightRecord.WEIGHT_MAX]))
       putMap("WEIGHT_MIN", massToJsMap(record[WeightRecord.WEIGHT_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
@@ -1,15 +1,20 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.WheelchairPushesRecord
+import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.utils.*
 import java.time.Instant
 
 class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord> {
+  private val aggregateMetrics = setOf(WheelchairPushesRecord.COUNT_TOTAL)
+
   override fun parseWriteRecord(records: ReadableArray): List<WheelchairPushesRecord> {
     return records.toMapList().map { map ->
       WheelchairPushesRecord(
@@ -34,10 +39,17 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
 
   override fun getAggregateRequest(record: ReadableMap): AggregateRequest {
     return AggregateRequest(
-      metrics = setOf(
-        WheelchairPushesRecord.COUNT_TOTAL
-      ),
+      metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+  override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    return AggregateGroupByPeriodRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }
@@ -46,6 +58,19 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
     return WritableNativeMap().apply {
       putDouble("COUNT_TOTAL", record[WheelchairPushesRecord.COUNT_TOTAL]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
@@ -49,7 +49,7 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
       timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
-      timeRangeSlicer = mapPeriodStringToPeriod(record.getString("timeRangeSlicer")),
+      timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -457,12 +457,16 @@ fun convertChangesTokenRequestOptionsFromJS(options: ReadableMap): ChangesTokenR
   )
 }
 
-fun mapPeriodStringToPeriod(period: String?): Period {
-  return when (period) {
-    "DAYS" -> Period.ofDays(1)
-    "WEEKS" -> Period.ofWeeks(1)
-    "MONTHS" -> Period.ofMonths(1)
-    "YEARS" -> Period.ofYears(1)
-    else -> Period.ofDays(1)
+fun mapJsPeriodToPeriod(period: ReadableMap?): Period {
+  if (period == null) {
+    return Period.ofDays(0)
+  }
+  val duration = period.getInt("duration")
+  return when (period.getString("period")) {
+    "DAYS" -> Period.ofDays(duration)
+    "WEEKS" -> Period.ofWeeks(duration)
+    "MONTHS" -> Period.ofMonths(duration)
+    "YEARS" -> Period.ofYears(duration)
+    else -> Period.ofDays(duration)
   }
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.Period
 import kotlin.reflect.KClass
 
 fun <T : Record> convertReactRequestOptionsFromJS(
@@ -454,4 +455,14 @@ fun convertChangesTokenRequestOptionsFromJS(options: ReadableMap): ChangesTokenR
     recordTypes = convertJsToRecordTypeSet(options.getArray("recordTypes")),
     dataOriginFilters = convertJsToDataOriginSet(options.getArray("dataOriginFilters")),
   )
+}
+
+fun mapPeriodStringToPeriod(period: String?): Period {
+  return when (period) {
+    "DAYS" -> Period.ofDays(1)
+    "WEEKS" -> Period.ofWeeks(1)
+    "MONTHS" -> Period.ofMonths(1)
+    "YEARS" -> Period.ofYears(1)
+    else -> Period.ofDays(1)
+  }
 }

--- a/android/src/oldarch/HealthConnectSpec.kt
+++ b/android/src/oldarch/HealthConnectSpec.kt
@@ -39,6 +39,9 @@ abstract class HealthConnectSpec internal constructor(context: ReactApplicationC
   abstract fun aggregateRecord(record: ReadableMap, promise: Promise);
 
   @ReactMethod
+  abstract fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise);
+
+  @ReactMethod
   abstract fun getChanges(options: ReadableMap, promise: Promise);
 
   @ReactMethod

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -164,7 +164,10 @@ export default function App() {
         startTime: getBeginningOfLast7Days().toISOString(),
         endTime: getTodayDate().toISOString(),
       },
-      timeRangeSlicer: 'DAYS',
+      timeRangeSlicer: {
+        period: 'DAYS',
+        duration: 1,
+      },
     }).then((result) => {
       console.log('Aggregated Group: ', JSON.stringify({ result }, null, 2));
     });

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -1,5 +1,6 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
+import type { TimeRangeSlicer } from './types/base.types';
 import type { HealthConnectRecord, Permission } from './types';
 
 type ReadRecordsOptions = {
@@ -35,7 +36,7 @@ export interface Spec extends TurboModule {
     recordType: string;
     startTime: string;
     endTime: string;
-    timeRangeSlicer: string;
+    timeRangeSlicer: TimeRangeSlicer;
   }): Promise<[]>;
   getChanges(request: {
     changesToken?: string;

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -31,6 +31,12 @@ export interface Spec extends TurboModule {
     startTime: string;
     endTime: string;
   }): Promise<{}>;
+  aggregateGroupByPeriod(record: {
+    recordType: string;
+    startTime: string;
+    endTime: string;
+    timeRangeSlicer: string;
+  }): Promise<[]>;
   getChanges(request: {
     changesToken?: string;
     recordTypes?: string[];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,8 @@ import { HealthConnectError } from './errors';
 import type {
   AggregateRequest,
   AggregateResult,
+  AggregateGroupByPeriodRequest,
+  AggregationResultGroupedByPeriod,
   AggregateResultRecordType,
   HealthConnectRecord,
   Permission,
@@ -148,6 +150,12 @@ export function aggregateRecord<T extends AggregateResultRecordType>(
   request: AggregateRequest<T>
 ): Promise<AggregateResult<T>> {
   return HealthConnect.aggregateRecord(request);
+}
+
+export function aggregateGroupByPeriod<T extends AggregateResultRecordType>(
+  request: AggregateGroupByPeriodRequest<T>
+): Promise<AggregationResultGroupedByPeriod<T>> {
+  return HealthConnect.aggregateGroupByPeriod(request);
 }
 
 export function getChanges(

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -5,6 +5,7 @@ import type {
   PowerResult,
   PressureResult,
   TimeRangeFilter,
+  TimeRangeSlicer,
   VelocityResult,
   VolumeResult,
 } from './base.types';
@@ -205,13 +206,30 @@ export type AggregateRecordResult =
 
 export type AggregateResultRecordType = AggregateRecordResult['recordType'];
 
+export interface AggregateRequest<T extends AggregateResultRecordType> {
+  recordType: T;
+  timeRangeFilter: TimeRangeFilter;
+  dataOriginFilter?: string[];
+}
+
 export type AggregateResult<T extends AggregateResultRecordType> = Omit<
   Extract<AggregateRecordResult, { recordType: T }>,
   'recordType'
 >;
 
-export interface AggregateRequest<T extends AggregateResultRecordType> {
+export interface AggregateGroupByPeriodRequest<
+  T extends AggregateResultRecordType
+> {
   recordType: T;
   timeRangeFilter: TimeRangeFilter;
+  timeRangeSlicer: TimeRangeSlicer;
   dataOriginFilter?: string[];
+}
+
+export interface AggregationResultGroupedByPeriod<
+  T extends AggregateResultRecordType
+> {
+  result: AggregateRequest<T>;
+  startTime: string;
+  endTime: string;
 }

--- a/src/types/base.types.ts
+++ b/src/types/base.types.ts
@@ -33,7 +33,10 @@ export type TimeRangeFilter =
       endTime: string;
     };
 
-export type TimeRangeSlicer = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
+export interface TimeRangeSlicer {
+  period: 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
+  duration: number;
+}
 
 export interface Energy {
   value: number;

--- a/src/types/base.types.ts
+++ b/src/types/base.types.ts
@@ -33,6 +33,8 @@ export type TimeRangeFilter =
       endTime: string;
     };
 
+export type TimeRangeSlicer = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
+
 export interface Energy {
   value: number;
   unit: 'calories' | 'joules' | 'kilocalories' | 'kilojoules';


### PR DESCRIPTION
## Summary
Currently, the library only supports the `aggregateRecord` function to retrieve aggregated data within a specified time range and does not support either `aggregateGroupByPeriod` or `aggregateGroupByDuration`. This PR adds the [aggregateGroupByPeriod](https://developer.android.com/health-and-fitness/guides/health-connect/develop/aggregate-data?hl=en#period) API to the library. Once this is approved, I am ready to submit another PR for [aggregateGroupByDuration](https://developer.android.com/health-and-fitness/guides/health-connect/develop/aggregate-data?hl=en#duration) and update the documentation accordingly.

### Related Issues:
https://github.com/matinzd/react-native-health-connect/issues/16
https://github.com/matinzd/react-native-health-connect/issues/116

## Background
I'm working on an app that visualizes various health data in charts. For example, to display daily weight changes over a month, we currently need to make 30 separate `aggregateRecord` requests, one for each day. With `aggregateGroupByPeriod`, we can potentially reduce the number of requests significantly. I suspect that the following error, which I occasionally encounter, may be related to exceeding the API call quota:

> android.health.connect.HealthConnectException: android.health.connect.HealthConnectException: API call quota exceeded, availableQuota: 0.0151130445 requested: 1

## Tests
I've made a couple of changes to the example app to test the new functionality:

- **insertSampleData**: Updated the sample data insertion. The `insertSampleData` function now inserts step count data for each day between 9 and 11 AM for the past 7 days (excluding today, as it can be before 9 AM).
- **AGGREGATE SAMPLE GROUP DATA button**: Added the "AGGREGATE SAMPLE GROUP DATA" button, as shown below, to test the `aggregateGroupByPeriod` API.

<img width="382" alt="AGGREGATE_SAMPLE_GROUP_DATA" src="https://github.com/user-attachments/assets/0f56b46f-8191-41c9-9ecf-ef96bc7bc13f">

### Log after `AGGREGATE SAMPLE GROUP DATA` button is pressed
```bash
# The user timezone is Asia/Tokyo
# No sample data is inserted for TODAY (2024-09-11)

Aggregated Group:  {
  "result": [
    {
      "endTime": "2024-09-04T15:00",
      "startTime": "2024-09-03T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 1000
      }
    },
    {
      "endTime": "2024-09-05T15:00",
      "startTime": "2024-09-04T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 2000
      }
    },
    {
      "endTime": "2024-09-06T15:00",
      "startTime": "2024-09-05T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 3000
      }
    },
    {
      "endTime": "2024-09-07T15:00",
      "startTime": "2024-09-06T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 4000
      }
    },
    {
      "endTime": "2024-09-08T15:00",
      "startTime": "2024-09-07T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 5000
      }
    },
    {
      "endTime": "2024-09-09T15:00",
      "startTime": "2024-09-08T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 6000
      }
    },
    {
      "endTime": "2024-09-10T15:00",
      "startTime": "2024-09-09T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 7000
      }
    },
    {
      "endTime": "2024-09-11T10:50:12.182",
      "startTime": "2024-09-10T15:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 0
      }
    }
  ]
}
```
