### PR TITLE
chore: exports record result types from module

### DIFF
--- a/src/types/results.types.ts
+++ b/src/types/results.types.ts
@@ -276,7 +276,7 @@ interface OxygenSaturationRecordResult extends OxygenSaturationRecord {}
 interface PowerRecordResult
   extends Replace<PowerRecord, 'samples', PowerResult[]> {}
 
-type HealthConnectRecordResult =
+export type HealthConnectRecordResult =
   | ActiveCaloriesBurnedRecordResult
   | BasalBodyTemperatureRecordResult
   | BasalMetabolicRateRecordResult


### PR DESCRIPTION
### Changes

A small QOL fix that exposes result types with `recordType`field present.