### PR TITLE
fix: fixes type definition for PowerRecordResult where samples would be missing time field

### DIFF
--- a/src/types/results.types.ts
+++ b/src/types/results.types.ts
@@ -3,7 +3,7 @@ import type {
   IntervalRecord,
   LengthResult,
   MassResult,
-  PowerResult,
+  PowerSampleResult,
   PressureResult,
   SpeedSampleResult,
   VolumeResult,
@@ -274,7 +274,7 @@ interface TotalCaloriesBurnedRecordResult
 interface OxygenSaturationRecordResult extends OxygenSaturationRecord {}
 
 interface PowerRecordResult
-  extends Replace<PowerRecord, 'samples', PowerResult[]> {}
+  extends Replace<PowerRecord, 'samples', PowerSampleResult[]> {}
 
 export type HealthConnectRecordResult =
   | ActiveCaloriesBurnedRecordResult


### PR DESCRIPTION
### Changes
Fixes (what I presume to be) a typo in `PowerRecordResult` where samples were replaced with the incorrect type. Power samples should include a `time` field (we actually parse them in the record [here](https://github.com/matinzd/react-native-health-connect/blob/main/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt#L32-L47), and for reference, [here](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/PowerRecord.Sample)'s the health-connect docs for `Power.Sample`).