### PR TITLE
feat: add aggregateGroupByDuration API

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -148,6 +148,24 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
     }
   }
 
+  fun aggregateGroupByDuration(record: ReadableMap, promise: Promise) {
+    throwUnlessClientIsAvailable(promise) {
+      coroutineScope.launch {
+        try {
+          val recordType = record.getString("recordType") ?: ""
+          val response = healthConnectClient.aggregateGroupByDuration(
+            ReactHealthRecord.getAggregateGroupByDurationRequest(
+              recordType, record
+            )
+          )
+          promise.resolve(ReactHealthRecord.parseAggregationResultGroupedByDuration(recordType, response))
+        } catch (e: Exception) {
+          promise.rejectWithException(e)
+        }
+      }
+    }
+  }
+
   fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise) {
     throwUnlessClientIsAvailable(promise) {
       coroutineScope.launch {

--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectModule.kt
@@ -71,6 +71,11 @@ class HealthConnectModule internal constructor(context: ReactApplicationContext)
   }
 
   @ReactMethod
+  override fun aggregateGroupByDuration(record: ReadableMap, promise: Promise) {
+    return manager.aggregateGroupByDuration(record, promise)
+  }
+
+  @ReactMethod
   override fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise) {
     return manager.aggregateGroupByPeriod(record, promise)
   }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalBodyTemperatureRecord.kt
@@ -1,9 +1,11 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BasalBodyTemperatureRecord
 import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
@@ -48,11 +50,19 @@ class ReactBasalBodyTemperatureRecord : ReactHealthRecordImpl<BasalBodyTemperatu
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BasalMetabolicRateRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Power
@@ -16,6 +18,7 @@ import dev.matinzd.healthconnect.utils.convertJsToDataOriginSet
 import dev.matinzd.healthconnect.utils.convertMetadataFromJSMap
 import dev.matinzd.healthconnect.utils.convertMetadataToJSMap
 import dev.matinzd.healthconnect.utils.getTimeRangeFilter
+import dev.matinzd.healthconnect.utils.mapJsDurationToDuration
 import dev.matinzd.healthconnect.utils.mapJsPeriodToPeriod
 import dev.matinzd.healthconnect.utils.toMapList
 import java.time.Instant
@@ -50,6 +53,15 @@ class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRe
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -57,6 +69,20 @@ class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRe
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
+    }
   }
 
   override fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodGlucoseRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodGlucoseRecord.kt
@@ -1,9 +1,11 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BloodGlucoseRecord
 import androidx.health.connect.client.records.MealType.MEAL_TYPE_UNKNOWN
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.BloodGlucose
@@ -53,7 +55,15 @@ class ReactBloodGlucoseRecord : ReactHealthRecordImpl<BloodGlucoseRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BloodPressureRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Pressure
@@ -58,6 +60,15 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -91,6 +102,20 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
         getPressureMap(record[BloodPressureRecord.DIASTOLIC_MAX]?.inMillimetersOfMercury ?: 0.0)
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyFatRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyFatRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyFatRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Percentage
@@ -40,7 +42,15 @@ class ReactBodyFatRecord : ReactHealthRecordImpl<BodyFatRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyTemperatureRecord.kt
@@ -1,9 +1,11 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyTemperatureMeasurementLocation
 import androidx.health.connect.client.records.BodyTemperatureRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Temperature
@@ -48,11 +50,19 @@ class ReactBodyTemperatureRecord : ReactHealthRecordImpl<BodyTemperatureRecord> 
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyWaterMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBodyWaterMassRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BodyWaterMassRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -36,11 +38,19 @@ class ReactBodyWaterMassRecord : ReactHealthRecordImpl<BodyWaterMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBoneMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBoneMassRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.BoneMassRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -41,11 +43,19 @@ class ReactBoneMassRecord : ReactHealthRecordImpl<BoneMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCervicalMucusRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCervicalMucusRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -42,11 +44,19 @@ class ReactCervicalMucusRecord : ReactHealthRecordImpl<CervicalMucusRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -62,6 +64,15 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -77,6 +88,20 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
       putDouble("RPM_MAX", record[CyclingPedalingCadenceRecord.RPM_MAX] ?: 0.0)
       putDouble("RPM_MIN", record[CyclingPedalingCadenceRecord.RPM_MIN] ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -47,6 +49,15 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -60,6 +71,20 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
     return WritableNativeMap().apply {
       putMap("DISTANCE", lengthToJsMap(record[DistanceRecord.DISTANCE_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.ElevationGainedRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -58,6 +69,20 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
     return WritableNativeMap().apply {
       putMap("ELEVATION_GAINED_TOTAL", lengthToJsMap(record[ElevationGainedRecord.ELEVATION_GAINED_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -1,12 +1,14 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.ExerciseLap
 import androidx.health.connect.client.records.ExerciseRoute
 import androidx.health.connect.client.records.ExerciseRouteResult
 import androidx.health.connect.client.records.ExerciseSegment
 import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -144,6 +146,15 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -163,6 +174,20 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
       }
       putMap("EXERCISE_DURATION_TOTAL", map)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.FloorsClimbedRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -58,6 +69,20 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
     return WritableNativeMap().apply {
       putDouble("FLOORS_CLIMBED_TOTAL", record[FloorsClimbedRecord.FLOORS_CLIMBED_TOTAL] ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecord.kt
@@ -2,9 +2,11 @@ package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.response.InsertRecordsResponse
 import androidx.health.connect.client.response.ReadRecordResponse
@@ -79,10 +81,22 @@ class ReactHealthRecord {
       return recordClass.getAggregateGroupByPeriodRequest(reactRequest)
     }
 
+    fun getAggregateGroupByDurationRequest(recordType: String, reactRequest: ReadableMap): AggregateGroupByDurationRequest {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.getAggregateGroupByDurationRequest(reactRequest)
+    }
+
     fun parseAggregationResult(recordType: String, result: AggregationResult): WritableNativeMap {
       val recordClass = createReactHealthRecordInstance<Record>(recordType)
 
       return recordClass.parseAggregationResult(result)
+    }
+
+    fun parseAggregationResultGroupedByDuration(recordType: String, result: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+      val recordClass = createReactHealthRecordInstance<Record>(recordType)
+
+      return recordClass.parseAggregationResultGroupedByDuration(result)
     }
 
     fun parseAggregationResultGroupedByPeriod(recordType: String, result: List<AggregationResultGroupedByPeriod>): WritableNativeArray {

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHealthRecordImpl.kt
@@ -1,9 +1,11 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -14,7 +16,9 @@ interface ReactHealthRecordImpl<T : Record> {
   fun parseWriteRecord(records: ReadableArray): List<T>
   fun parseRecord(record: T): WritableNativeMap
   fun getAggregateRequest(record: ReadableMap): AggregateRequest
+  fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest
   fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest
   fun parseAggregationResult(record: AggregationResult): WritableNativeMap
+  fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray
   fun parseAggregationResultGroupedByPeriod(record: List<AggregationResultGroupedByPeriod>): WritableNativeArray
 }

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -63,6 +65,15 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -79,6 +90,20 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
       putDouble("BPM_MIN", record[HeartRateRecord.BPM_MIN]?.toDouble() ?: 0.0)
       putDouble("MEASUREMENTS_COUNT", record[HeartRateRecord.MEASUREMENTS_COUNT]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateVariabilityRmssdRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -40,11 +42,19 @@ class ReactHeartRateVariabilityRmssdRecord :
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HeightRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -46,6 +48,15 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -61,6 +72,20 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
       putMap("HEIGHT_MIN", lengthToJsMap(record[HeightRecord.HEIGHT_MIN]))
       putMap("HEIGHT_MAX", lengthToJsMap(record[HeightRecord.HEIGHT_MAX]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.HydrationRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactHydrationRecord : ReactHealthRecordImpl<HydrationRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -58,6 +69,20 @@ class ReactHydrationRecord : ReactHealthRecordImpl<HydrationRecord> {
     return WritableNativeMap().apply {
       putMap("VOLUME_TOTAL", volumeToJsMap(record[HydrationRecord.VOLUME_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactIntermenstrualBleedingRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactIntermenstrualBleedingRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.IntermenstrualBleedingRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -37,11 +39,19 @@ class ReactIntermenstrualBleedingRecord : ReactHealthRecordImpl<IntermenstrualBl
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactLeanBodyMassRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactLeanBodyMassRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.LeanBodyMassRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -36,11 +38,19 @@ class ReactLeanBodyMassRecord : ReactHealthRecordImpl<LeanBodyMassRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationFlowRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationFlowRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MenstruationFlowRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -40,11 +42,19 @@ class ReactMenstruationFlowRecord : ReactHealthRecordImpl<MenstruationFlowRecord
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationPeriodRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactMenstruationPeriodRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MenstruationPeriodRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -40,11 +42,19 @@ class ReactMenstruationPeriodRecord : ReactHealthRecordImpl<MenstruationPeriodRe
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
@@ -1,9 +1,11 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.MealType
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -173,6 +175,15 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -233,6 +244,20 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
       putMap("VITAMIN_E_TOTAL", massToJsMap(record[NutritionRecord.VITAMIN_E_TOTAL]))
       putMap("VITAMIN_K_TOTAL", massToJsMap(record[NutritionRecord.VITAMIN_K_TOTAL]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactOvulationTestRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactOvulationTestRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.OvulationTestRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -40,11 +42,19 @@ class ReactOvulationTestRecord : ReactHealthRecordImpl<OvulationTestRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactOxygenSaturationRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactOxygenSaturationRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.OxygenSaturationRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.units.Percentage
@@ -40,11 +42,19 @@ class ReactOxygenSaturationRecord : ReactHealthRecordImpl<OxygenSaturationRecord
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.PowerRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -62,6 +64,15 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -77,6 +88,20 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
       putMap("POWER_MAX", powerToJsMap(record[PowerRecord.POWER_MAX]))
       putMap("POWER_MIN", powerToJsMap(record[PowerRecord.POWER_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRespiratoryRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRespiratoryRateRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.RespiratoryRateRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -37,11 +39,19 @@ class ReactRespiratoryRateRecord : ReactHealthRecordImpl<RespiratoryRateRecord> 
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.RestingHeartRateRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -46,6 +48,16 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -61,6 +73,20 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
       putDouble("BPM_MAX", record[RestingHeartRateRecord.BPM_MAX]?.toDouble() ?: 0.0)
       putDouble("BPM_MIN", record[RestingHeartRateRecord.BPM_MIN]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSexualActivityRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSexualActivityRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SexualActivityRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -39,11 +41,19 @@ class ReactSexualActivityRecord : ReactHealthRecordImpl<SexualActivityRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -63,6 +65,15 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -79,6 +90,20 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
         record[SleepSessionRecord.SLEEP_DURATION_TOTAL]?.seconds?.toDouble() ?: 0.0
       )
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.SpeedRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -62,6 +64,15 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -77,6 +88,20 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
       putMap("SPEED_MAX", velocityToJsMap(record[SpeedRecord.SPEED_MAX]))
       putMap("SPEED_MIN", velocityToJsMap(record[SpeedRecord.SPEED_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.StepsCadenceRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -62,6 +64,15 @@ class ReactStepsCadenceRecord : ReactHealthRecordImpl<StepsCadenceRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -77,6 +88,20 @@ class ReactStepsCadenceRecord : ReactHealthRecordImpl<StepsCadenceRecord> {
       putDouble("RATE_MAX", record[StepsCadenceRecord.RATE_MAX]?.toDouble() ?: 0.0)
       putDouble("RATE_MIN", record[StepsCadenceRecord.RATE_MIN]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -58,6 +69,20 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
     return WritableNativeMap().apply {
       putDouble("COUNT_TOTAL", record[StepsRecord.COUNT_TOTAL]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -76,6 +87,20 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
       }
       putMap("ENERGY_TOTAL", map)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.Vo2MaxRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,11 +47,19 @@ class ReactVo2MaxRecord : ReactHealthRecordImpl<Vo2MaxRecord> {
     throw AggregationNotSupported()
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    throw AggregationNotSupported()
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     throw AggregationNotSupported()
   }
 
   override fun parseAggregationResult(record: AggregationResult): WritableNativeMap {
+    throw AggregationNotSupported()
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
     throw AggregationNotSupported()
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -46,6 +48,15 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -61,6 +72,20 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
       putMap("WEIGHT_MAX", massToJsMap(record[WeightRecord.WEIGHT_MAX]))
       putMap("WEIGHT_MIN", massToJsMap(record[WeightRecord.WEIGHT_MIN]))
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
@@ -1,8 +1,10 @@
 package dev.matinzd.healthconnect.records
 
 import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.aggregate.AggregationResultGroupedByDuration
 import androidx.health.connect.client.aggregate.AggregationResultGroupedByPeriod
 import androidx.health.connect.client.records.WheelchairPushesRecord
+import androidx.health.connect.client.request.AggregateGroupByDurationRequest
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import com.facebook.react.bridge.ReadableArray
@@ -45,6 +47,15 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
     )
   }
 
+  override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+    return AggregateGroupByDurationRequest(
+      metrics = aggregateMetrics,
+      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+      dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+    )
+  }
+
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
@@ -58,6 +69,20 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
     return WritableNativeMap().apply {
       putDouble("COUNT_TOTAL", record[WheelchairPushesRecord.COUNT_TOTAL]?.toDouble() ?: 0.0)
       putArray("dataOrigins", convertDataOriginsToJsArray(record.dataOrigins))
+    }
+  }
+
+  override fun parseAggregationResultGroupedByDuration(record: List<AggregationResultGroupedByDuration>): WritableNativeArray {
+    return WritableNativeArray().apply {
+      record.forEach {
+        val map = WritableNativeMap().apply {
+          putMap("result", parseAggregationResult(it.result))
+          putString("startTime", it.startTime.toString())
+          putString("endTime", it.endTime.toString())
+          putString("zoneOffset", it.zoneOffset.toString())
+        }
+        pushMap(map)
+      }
     }
   }
 

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.Duration
 import java.time.Period
 import kotlin.reflect.KClass
 
@@ -457,16 +458,31 @@ fun convertChangesTokenRequestOptionsFromJS(options: ReadableMap): ChangesTokenR
   )
 }
 
+fun mapJsDurationToDuration(duration: ReadableMap?): Duration {
+  if (duration == null) {
+    return Duration.ofDays(0)
+  }
+  val length = duration.getInt("length").toLong()
+  return when (duration.getString("duration")) {
+    "MILLIS" -> Duration.ofMillis(length)
+    "SECONDS" -> Duration.ofSeconds(length)
+    "MINUTES" -> Duration.ofMinutes(length)
+    "HOURS" -> Duration.ofHours(length)
+    "DAYS" -> Duration.ofDays(length)
+    else -> Duration.ofDays(length)
+  }
+}
+
 fun mapJsPeriodToPeriod(period: ReadableMap?): Period {
   if (period == null) {
     return Period.ofDays(0)
   }
-  val duration = period.getInt("duration")
+  val length = period.getInt("length")
   return when (period.getString("period")) {
-    "DAYS" -> Period.ofDays(duration)
-    "WEEKS" -> Period.ofWeeks(duration)
-    "MONTHS" -> Period.ofMonths(duration)
-    "YEARS" -> Period.ofYears(duration)
-    else -> Period.ofDays(duration)
+    "DAYS" -> Period.ofDays(length)
+    "WEEKS" -> Period.ofWeeks(length)
+    "MONTHS" -> Period.ofMonths(length)
+    "YEARS" -> Period.ofYears(length)
+    else -> Period.ofDays(length)
   }
 }

--- a/android/src/oldarch/HealthConnectSpec.kt
+++ b/android/src/oldarch/HealthConnectSpec.kt
@@ -39,6 +39,9 @@ abstract class HealthConnectSpec internal constructor(context: ReactApplicationC
   abstract fun aggregateRecord(record: ReadableMap, promise: Promise);
 
   @ReactMethod
+  abstract fun aggregateGroupByDuration(record: ReadableMap, promise: Promise);
+
+  @ReactMethod
   abstract fun aggregateGroupByPeriod(record: ReadableMap, promise: Promise);
 
   @ReactMethod

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Button, StyleSheet, View } from 'react-native';
 import {
   aggregateRecord,
+  aggregateGroupByDuration,
   aggregateGroupByPeriod,
   getGrantedPermissions,
   initialize,
@@ -21,20 +22,20 @@ import {
 } from 'react-native-health-connect';
 
 const getBeginningOfLast7Days = () => {
-  const day = new Date();
-  day.setDate(day.getDate() - 7);
-  day.setHours(0, 0, 0, 0);
-  return day;
+  const date = new Date();
+  date.setDate(date.getDate() - 7);
+  date.setHours(0, 0, 0, 0);
+  return date;
 };
 
 const getBeginningOfLast14Days = () => {
-  const day = new Date();
-  day.setDate(day.getDate() - 14);
-  day.setHours(0, 0, 0, 0);
-  return day;
+  const date = new Date();
+  date.setDate(date.getDate() - 14);
+  date.setHours(0, 0, 0, 0);
+  return date;
 };
 
-const getTodayDate = (): Date => {
+const now = () => {
   return new Date();
 };
 
@@ -73,17 +74,17 @@ export default function App() {
       (acc: HealthConnectRecord[], _, i) => {
         // Step count increases by 1000 starting from the first day (7 days ago)
         const stepCount = startingStepCount + i * 1000;
-        const day = new Date();
+        const date = new Date();
 
         // Get the date for each of the last 7 days, starting from 7 days ago (excluding today)
-        day.setDate(day.getDate() - (days - i));
+        date.setDate(date.getDate() - (days - i));
 
         // Set start time to 9am
-        const startTime = new Date(day);
+        const startTime = new Date(date);
         startTime.setHours(9, 0, 0, 0);
 
         // Set end time to 11am
-        const endTime = new Date(day);
+        const endTime = new Date(date);
         endTime.setHours(11, 0, 0, 0);
 
         const record: HealthConnectRecord = {
@@ -122,7 +123,7 @@ export default function App() {
       timeRangeFilter: {
         operator: 'between',
         startTime: getBeginningOfLast14Days().toISOString(),
-        endTime: getTodayDate().toISOString(),
+        endTime: now().toISOString(),
       },
     })
       .then((result) => {
@@ -149,10 +150,30 @@ export default function App() {
       timeRangeFilter: {
         operator: 'between',
         startTime: getBeginningOfLast7Days().toISOString(),
-        endTime: getTodayDate().toISOString(),
+        endTime: now().toISOString(),
       },
     }).then((result) => {
       console.log('Aggregated record: ', { result });
+    });
+  };
+
+  const aggregateSampleGroupByDuration = () => {
+    aggregateGroupByDuration({
+      recordType: 'Steps',
+      timeRangeFilter: {
+        operator: 'between',
+        startTime: getBeginningOfLast7Days().toISOString(),
+        endTime: now().toISOString(),
+      },
+      timeRangeSlicer: {
+        duration: 'DAYS',
+        length: 2,
+      },
+    }).then((result) => {
+      console.log(
+        'Aggregated Group by Duration: ',
+        JSON.stringify({ result }, null, 2)
+      );
     });
   };
 
@@ -162,14 +183,17 @@ export default function App() {
       timeRangeFilter: {
         operator: 'between',
         startTime: getBeginningOfLast7Days().toISOString(),
-        endTime: getTodayDate().toISOString(),
+        endTime: now().toISOString(),
       },
       timeRangeSlicer: {
         period: 'DAYS',
-        duration: 1,
+        length: 1,
       },
     }).then((result) => {
-      console.log('Aggregated Group: ', JSON.stringify({ result }, null, 2));
+      console.log(
+        'Aggregated Group by Period: ',
+        JSON.stringify({ result }, null, 2)
+      );
     });
   };
 
@@ -225,7 +249,11 @@ export default function App() {
       <Button title="Read specific data" onPress={readSampleDataSingle} />
       <Button title="Aggregate sample data" onPress={aggregateSampleData} />
       <Button
-        title="Aggregate sample group data"
+        title="Aggregate sample group data by duration"
+        onPress={aggregateSampleGroupByDuration}
+      />
+      <Button
+        title="Aggregate sample group data by period"
         onPress={aggregateSampleGroupByPeriod}
       />
     </View>

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -31,6 +31,12 @@ export interface Spec extends TurboModule {
     startTime: string;
     endTime: string;
   }): Promise<{}>;
+  aggregateGroupByDuration(record: {
+    recordType: string;
+    startTime: string;
+    endTime: string;
+    timeRangeSlicer: Object;
+  }): Promise<[]>;
   aggregateGroupByPeriod(record: {
     recordType: string;
     startTime: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,9 @@ import { HealthConnectError } from './errors';
 import type {
   AggregateRequest,
   AggregateResult,
+  AggregateGroupByDurationRequest,
   AggregateGroupByPeriodRequest,
-  AggregationResultGroupedByPeriod,
+  AggregationGroupResult,
   AggregateResultRecordType,
   HealthConnectRecord,
   Permission,
@@ -152,9 +153,15 @@ export function aggregateRecord<T extends AggregateResultRecordType>(
   return HealthConnect.aggregateRecord(request);
 }
 
+export function aggregateGroupByDuration<T extends AggregateResultRecordType>(
+  request: AggregateGroupByDurationRequest<T>
+): Promise<AggregationGroupResult<T>[]> {
+  return HealthConnect.aggregateGroupByDuration(request);
+}
+
 export function aggregateGroupByPeriod<T extends AggregateResultRecordType>(
   request: AggregateGroupByPeriodRequest<T>
-): Promise<AggregationResultGroupedByPeriod<T>> {
+): Promise<AggregationGroupResult<T>[]> {
   return HealthConnect.aggregateGroupByPeriod(request);
 }
 

--- a/src/types/aggregate.types.ts
+++ b/src/types/aggregate.types.ts
@@ -5,7 +5,8 @@ import type {
   PowerResult,
   PressureResult,
   TimeRangeFilter,
-  TimeRangeSlicer,
+  DurationRangeSlicer,
+  PeriodRangeSlicer,
   VelocityResult,
   VolumeResult,
 } from './base.types';
@@ -217,19 +218,26 @@ export type AggregateResult<T extends AggregateResultRecordType> = Omit<
   'recordType'
 >;
 
+export interface AggregateGroupByDurationRequest<
+  T extends AggregateResultRecordType
+> {
+  recordType: T;
+  timeRangeFilter: TimeRangeFilter;
+  timeRangeSlicer: DurationRangeSlicer;
+  dataOriginFilter?: string[];
+}
+
 export interface AggregateGroupByPeriodRequest<
   T extends AggregateResultRecordType
 > {
   recordType: T;
   timeRangeFilter: TimeRangeFilter;
-  timeRangeSlicer: TimeRangeSlicer;
+  timeRangeSlicer: PeriodRangeSlicer;
   dataOriginFilter?: string[];
 }
 
-export interface AggregationResultGroupedByPeriod<
-  T extends AggregateResultRecordType
-> {
-  result: AggregateRequest<T>;
+export interface AggregationGroupResult<T extends AggregateResultRecordType> {
+  result: AggregateResult<T>;
   startTime: string;
   endTime: string;
 }

--- a/src/types/base.types.ts
+++ b/src/types/base.types.ts
@@ -33,9 +33,16 @@ export type TimeRangeFilter =
       endTime: string;
     };
 
-export interface TimeRangeSlicer {
+// Duration is a fixed length of time in Java (daylight savings are ignored for DAYS)
+export interface DurationRangeSlicer {
+  duration: 'MILLIS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS';
+  length: number;
+}
+
+// Period is date-based amount of time in Java
+export interface PeriodRangeSlicer {
   period: 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
-  duration: number;
+  length: number;
 }
 
 export interface Energy {


### PR DESCRIPTION
## Summary

Following https://github.com/matinzd/react-native-health-connect/pull/157, I have made a similar addition for [aggregateGroupByDuration](https://developer.android.com/health-and-fitness/guides/health-connect/develop/aggregate-data?hl=en#duration).

Difference between `Duration` and `Period` classes in Java:
- **Duration**: A fixed length of time (daylight savings effects are ignored)
- **Period**: Date-based amount of time (days, weeks, months and years)

**AGGREGATE SAMPLE GROUP DATA BY DURATION button**: Added the "AGGREGATE SAMPLE GROUP DATA BY DURATION" button, as shown below, to test the `aggregateGroupByDuration API`.

<img width="410" alt="image" src="https://github.com/user-attachments/assets/2c4c4f51-014e-41de-ae9d-630e91598d2e">

### Log after AGGREGATE SAMPLE GROUP DATA BY DURATION button is pressed

```bash
# timeRangeSlicer.duration: DAYS
# timeRangeSlicer.length: 2

Aggregated Group by Duration:  {
  "result": [
    {
      "endTime": "2024-10-06T15:00:00Z",
      "startTime": "2024-10-04T15:00:00Z",
      "zoneOffset": "+09:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 3000
      }
    },
    {
      "endTime": "2024-10-08T15:00:00Z",
      "startTime": "2024-10-06T15:00:00Z",
      "zoneOffset": "+09:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 7000
      }
    },
    {
      "endTime": "2024-10-10T15:00:00Z",
      "startTime": "2024-10-08T15:00:00Z",
      "zoneOffset": "+09:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 11000
      }
    },
    {
      "endTime": "2024-10-12T14:57:39.714Z",
      "startTime": "2024-10-10T15:00:00Z",
      "zoneOffset": "+09:00",
      "result": {
        "dataOrigins": [],
        "COUNT_TOTAL": 7000
      }
    }
  ]
}
```
