### PR TITLE
fix: saving VO2_MAX recording does not work

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactVo2MaxRecord.kt
@@ -24,7 +24,7 @@ class ReactVo2MaxRecord : ReactHealthRecordImpl<Vo2MaxRecord> {
       Vo2MaxRecord(
         time = Instant.parse(map.getString("time")),
         zoneOffset = null,
-        vo2MillilitersPerMinuteKilogram = map.getDouble("vo2Max"),
+        vo2MillilitersPerMinuteKilogram = map.getDouble("vo2MillilitersPerMinuteKilogram"),
         measurementMethod = map.getSafeInt(
           "measurementMethod",
           Vo2MaxRecord.MEASUREMENT_METHOD_OTHER


### PR DESCRIPTION
Hi!

I'm trying to record VO2_MAX, but the "vo2MillilitersPerMinuteKilogram" field is being transmitted from the JS side