### PR TITLE
fix: call promise.resolve() in revokeAllPermissions()

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt
@@ -95,6 +95,7 @@ class HealthConnectManager(private val applicationContext: ReactApplicationConte
     throwUnlessClientIsAvailable(promise) {
       coroutineScope.launch {
         healthConnectClient.permissionController.revokeAllPermissions()
+        promise.resolve(true)
       }
     }
   }


### PR DESCRIPTION
Thanks for a good library 🥳 

When I await `revokeAllPermissions()` in JavaScript, the function was blocking without resolving the Promise. 
I noticed that `revokeAllPermissions()` in Native Layer does not call promote.resolve(), so I made it call.

I created a patch locally and confirmed that it works.