### PR TITLE
feat: add `READ_HEALTH_DATA_HISTORY` permission

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   implementation "com.facebook.react:react-native"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-  implementation "androidx.health.connect:connect-client:1.1.0-alpha06"
+  implementation "androidx.health.connect:connect-client:1.1.0-alpha11"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
@@ -19,6 +19,10 @@ class PermissionUtils {
           return@mapNotNull HealthPermission.PERMISSION_WRITE_EXERCISE_ROUTE
         }
 
+        if (accessType == "read" && recordType == "ReadHealthDataHistory") {
+          return@mapNotNull HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY
+        }
+
         val recordClass = reactRecordTypeToClassMap[recordType]
           ?: throw InvalidRecordType()
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.health.WRITE_EXERCISE"/>
     <uses-permission android:name="android.permission.health.READ_EXERCISE_ROUTES"/>
     <uses-permission android:name="android.permission.health.WRITE_EXERCISE_ROUTE"/>
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
 
     <application
       android:name=".MainApplication"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         buildToolsVersion = "34.0.0"
         minSdkVersion = 26
-        compileSdkVersion = 34
+        compileSdkVersion = 35
         targetSdkVersion = 34
         ndkVersion = "25.1.8937393"
         kotlinVersion = "1.8.0"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -261,6 +261,10 @@ export default function App() {
         accessType: 'write',
         recordType: 'ExerciseRoute',
       },
+      {
+        accessType: 'read',
+        recordType: 'ReadHealthDataHistory',
+      },
     ]).then((permissions) => {
       console.log('Granted permissions on request ', { permissions });
     });

--- a/src/NativeHealthConnect.ts
+++ b/src/NativeHealthConnect.ts
@@ -4,6 +4,7 @@ import type {
   HealthConnectRecord,
   Permission,
   WriteExerciseRoutePermission,
+  ReadHealthDataHistoryPermission,
 } from './types';
 import type { ExerciseRoute } from './types/base.types';
 
@@ -23,7 +24,11 @@ export interface Spec extends TurboModule {
   openHealthConnectSettings: () => void;
   openHealthConnectDataManagement: (providerPackageName?: string) => void;
   requestPermission(
-    permissions: (Permission | WriteExerciseRoutePermission)[]
+    permissions: (
+      | Permission
+      | WriteExerciseRoutePermission
+      | ReadHealthDataHistoryPermission
+    )[]
   ): Promise<Permission[]>;
   requestExerciseRoute(recordId: string): Promise<ExerciseRoute>;
   getGrantedPermissions(): Promise<Permission[]>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import type {
   GetChangesRequest,
   GetChangesResults,
   WriteExerciseRoutePermission,
+  ReadHealthDataHistoryPermission,
 } from './types';
 import type { ExerciseRoute, TimeRangeFilter } from './types/base.types';
 
@@ -98,7 +99,11 @@ export function openHealthConnectDataManagement(
  * @returns granted permissions
  */
 export function requestPermission(
-  permissions: (Permission | WriteExerciseRoutePermission)[]
+  permissions: (
+    | Permission
+    | WriteExerciseRoutePermission
+    | ReadHealthDataHistoryPermission
+  )[]
 ): Promise<Permission[]> {
   return HealthConnect.requestPermission(permissions);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,11 @@ export interface WriteExerciseRoutePermission {
   recordType: 'ExerciseRoute';
 }
 
+export interface ReadHealthDataHistoryPermission {
+  accessType: 'read';
+  recordType: 'ReadHealthDataHistory';
+}
+
 export * from './records.types';
 export * from './results.types';
 export * from './aggregate.types';


### PR DESCRIPTION
This PR adds the `READ_HEALTH_DATA_HISTORY` that lets apps read health data beyond the default limit of 30 days.
- Updated Health Connect dependency to `androidx.health.connect:connect-client:1.1.0-alpha11` because support for this permission is available since alpha10 and above. [link](https://developer.android.com/jetpack/androidx/releases/health-connect#1.1.0-alpha10)
- This change requires `compileSdkVersion` to be `35`.

I have tested my changes against an Android 13 device, and it works: [Screenshot](https://ibb.co/ZRJrj7Lr)

However, I am unable to get this permission to work on an Android 14 device. I have no knowledge of Kotlin and I was mostly able to make this work by 'breadcrumb-ing' the `ExerciseRoute` types and methods throughout this project.

Edit: The Android 14 device is a Samsung device running OneUI 6.1, so it could also be something funky that Samsung is doing.