### PR TITLE
feat: add device manufacturer and model from metadata to response

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -161,6 +161,8 @@ fun convertMetadataToJSMap(meta: Metadata): WritableNativeMap {
     putString("lastModifiedTime", meta.lastModifiedTime.toString())
     putMap("device", convertDeviceToJSMap(meta.device))
     putInt("recordingMethod", meta.recordingMethod)
+    putString("manufacturer", meta.device?.manufacturer)
+    putString("model", meta.device?.model)
   }
 }
 


### PR DESCRIPTION
Adds manufacturer and model info from the [metadata](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/metadata/Device#public-properties) if available