### PR TITLE
fix: include native stack trace in rejected errors

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/ExceptionsUtils.kt
@@ -37,5 +37,5 @@ fun Promise.rejectWithException(exception: Exception) {
     else -> "UNKNOWN_ERROR"
   }
 
-  this.reject(code, exception.message)
+  this.reject(code, exception.message, exception)
 }


### PR DESCRIPTION
Currently rejected errors do not include the native stack trace (in `nativeStackAndroid`), this PR fixes this.

For context our monitoring shows for some users an error message "count must not be less than 1, currently 0" in getChanges for steps records and we can't reproduce it locally. We would like to see the native stack trace in order to have more information about where this error occurs