### PR TITLE
Fix (expo): Update SDK versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Then add the prebuild [config plugin](https://docs.expo.io/guides/config-plugins
         "expo-build-properties",
         {
           "android": {
-            "compileSdkVersion": 34,
-            "targetSdkVersion": 34,
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35,
             "minSdkVersion": 26
           },
         }


### PR DESCRIPTION
`compileSdkVersion` and `targetSdkVersion` must be at least `35`.

Got errors for `34`