### PR TITLE
fix: use LocalDateTime TimeRangeFilter for grouped aggregation

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -50,7 +50,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     return AggregateGroupByDurationRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
@@ -59,7 +59,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -14,6 +14,8 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.Duration
 import java.time.Period
@@ -97,6 +99,51 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
 
   val endTime =
     if (timeRangeFilter.hasKey("endTime")) Instant.parse(timeRangeFilter.getString("endTime")) else null
+
+  when (operator) {
+    "between" -> {
+      if (startTime == null || endTime == null) {
+        throw Exception("Start time and end time should be provided")
+      }
+
+      return TimeRangeFilter.between(startTime, endTime)
+    }
+    "after" -> {
+      if (startTime == null) {
+        throw Exception("Start time should be provided")
+      }
+
+      return TimeRangeFilter.after(startTime)
+    }
+    "before" -> {
+      if (endTime == null) {
+        throw Exception("End time should be provided")
+      }
+
+      return TimeRangeFilter.before(endTime)
+    }
+    else -> {
+      if (startTime == null || endTime == null) {
+        throw Exception("Start time and end time should be provided")
+      }
+
+      return TimeRangeFilter.between(startTime, endTime)
+    }
+  }
+}
+
+fun ReadableMap.getTimeRangeFilterLocal(key: String? = null): TimeRangeFilter {
+  val timeRangeFilter = if (key != null) this.getMap(key)
+    ?: throw Exception("Time range filter should be provided") else this
+
+  val operator = timeRangeFilter.getString("operator")
+  val zone = ZoneId.systemDefault()
+
+  val startTime: LocalDateTime? =
+    if (timeRangeFilter.hasKey("startTime")) Instant.parse(timeRangeFilter.getString("startTime")).atZone(zone).toLocalDateTime() else null
+
+  val endTime: LocalDateTime? =
+    if (timeRangeFilter.hasKey("endTime")) Instant.parse(timeRangeFilter.getString("endTime")).atZone(zone).toLocalDateTime() else null
 
   when (operator) {
     "between" -> {


### PR DESCRIPTION
## Problem

`aggregateGroupByDuration` and `aggregateGroupByPeriod` throw `IllegalArgumentException` on Android devices where the Health Connect system module (updated via Google Play) requires `LocalDateTime`-based `TimeRangeFilter` for grouped aggregation requests.

**Error**: `Either use TimeRangeFilter with LocalDateTime or AggregateGroupByDurationRequest`

### Root Cause

`getTimeRangeFilter()` in `HealthConnectUtils.kt` always parses ISO 8601 strings as `Instant` and builds `TimeRangeFilter.between(Instant, Instant)`. While the compile-time client SDK (`connect-client:1.1.0-alpha11`) accepts this, the runtime Health Connect system service on newer Android devices enforces `LocalDateTime`-based filters for grouped aggregation.

The `TimeRangeFilter` class has dual fields:
- `startTime`/`endTime` (`Instant`, nullable)
- `localStartTime`/`localEndTime` (`LocalDateTime`, nullable)

When `TimeRangeFilter.between(Instant, Instant)` is used, the Instant fields are populated but LocalDateTime fields are null — causing the system service validation to reject the request.

## Fix

Added `getTimeRangeFilterLocal()` extension function on `ReadableMap` that:
1. Parses ISO 8601 strings as `Instant` (same as before)
2. Converts to `LocalDateTime` via `Instant.atZone(ZoneId.systemDefault()).toLocalDateTime()`
3. Creates `TimeRangeFilter.between(LocalDateTime, LocalDateTime)`

Updated `ReactStepsRecord` to use `getTimeRangeFilterLocal` in `getAggregateGroupByDurationRequest` and `getAggregateGroupByPeriodRequest`.

The existing `getTimeRangeFilter()` is preserved for non-grouped requests (e.g., `ReadRecordsRequest`, `AggregateRequest`) which still work fine with `Instant`.

**Note**: Ideally all record types that implement `getAggregateGroupByDurationRequest` / `getAggregateGroupByPeriodRequest` should be updated to use `getTimeRangeFilterLocal` as well. This PR only updates `ReactStepsRecord` as that's the one we hit in production, but the same fix should apply to all record types.

## patch-package patch

<details>
<summary>react-native-health-connect+3.5.0.patch</summary>

```diff
diff --git a/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt b/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
index 0675309..102f970 100644
--- a/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+++ b/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
@@ -50,7 +50,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
     return AggregateGroupByDurationRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
@@ -59,7 +59,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )
diff --git a/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt b/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
index ce3c5d9..9a02150 100644
--- a/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
+++ b/node_modules/react-native-health-connect/android/src/main/java/dev/matinzd/healthconnect/utils/HealthConnectUtils.kt
@@ -14,6 +14,8 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import dev.matinzd.healthconnect.records.*
 import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.Duration
 import java.time.Period
@@ -130,6 +132,51 @@ fun ReadableMap.getTimeRangeFilter(key: String? = null): TimeRangeFilter {
   }
 }
 
+fun ReadableMap.getTimeRangeFilterLocal(key: String? = null): TimeRangeFilter {
+  val timeRangeFilter = if (key != null) this.getMap(key)
+    ?: throw Exception("Time range filter should be provided") else this
+
+  val operator = timeRangeFilter.getString("operator")
+  val zone = ZoneId.systemDefault()
+
+  val startTime: LocalDateTime? =
+    if (timeRangeFilter.hasKey("startTime")) Instant.parse(timeRangeFilter.getString("startTime")).atZone(zone).toLocalDateTime() else null
+
+  val endTime: LocalDateTime? =
+    if (timeRangeFilter.hasKey("endTime")) Instant.parse(timeRangeFilter.getString("endTime")).atZone(zone).toLocalDateTime() else null
+
+  when (operator) {
+    "between" -> {
+      if (startTime == null || endTime == null) {
+        throw Exception("Start time and end time should be provided")
+      }
+
+      return TimeRangeFilter.between(startTime, endTime)
+    }
+    "after" -> {
+      if (startTime == null) {
+        throw Exception("Start time should be provided")
+      }
+
+      return TimeRangeFilter.after(startTime)
+    }
+    "before" -> {
+      if (endTime == null) {
+        throw Exception("End time should be provided")
+      }
+
+      return TimeRangeFilter.before(endTime)
+    }
+    else -> {
+      if (startTime == null || endTime == null) {
+        throw Exception("Start time and end time should be provided")
+      }
+
+      return TimeRangeFilter.between(startTime, endTime)
+    }
+  }
+}
+
 fun convertMetadataFromJSMap(meta: ReadableMap?): Metadata {
   if (meta == null) {
     return Metadata()
```

</details>