### PR TITLE
fix(expo): register the Health Connect permission delegate during prebuild

### DIFF
--- a/__tests__/app.plugin.test.js
+++ b/__tests__/app.plugin.test.js
@@ -1,0 +1,207 @@
+const {
+  setHealthConnectManifest,
+  addViewPermissionUsageAlias,
+} = require('../app.plugin');
+
+const RATIONALE_ACTION = 'androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE';
+const VIEW_PERMISSION_USAGE_ACTION =
+  'android.intent.action.VIEW_PERMISSION_USAGE';
+
+/** A manifest shaped like the one `expo prebuild` generates. */
+function createAndroidManifest({ mainActivityIntentFilters } = {}) {
+  return {
+    manifest: {
+      '$': { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+      'uses-permission': [
+        { $: { 'android:name': 'android.permission.INTERNET' } },
+      ],
+      'application': [
+        {
+          $: { 'android:name': '.MainApplication' },
+          activity: [
+            {
+              $: {
+                'android:name': '.MainActivity',
+                'android:exported': 'true',
+              },
+              ...(mainActivityIntentFilters === null
+                ? {}
+                : {
+                    'intent-filter': mainActivityIntentFilters ?? [
+                      {
+                        action: [
+                          {
+                            $: { 'android:name': 'android.intent.action.MAIN' },
+                          },
+                        ],
+                        category: [
+                          {
+                            $: {
+                              'android:name':
+                                'android.intent.category.LAUNCHER',
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  }),
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+const getMainActivity = (manifest) =>
+  manifest.manifest.application[0].activity.find(
+    (activity) => activity.$['android:name'] === '.MainActivity'
+  );
+
+const getAliases = (manifest) =>
+  manifest.manifest.application[0]['activity-alias'] ?? [];
+
+const hasAction = (node, action) =>
+  node.action?.some((item) => item.$['android:name'] === action) ?? false;
+
+describe('setHealthConnectManifest', () => {
+  it('declares the rationale intent filter used through Android 13', () => {
+    const manifest = setHealthConnectManifest(createAndroidManifest());
+
+    const filters = getMainActivity(manifest)['intent-filter'];
+    expect(
+      filters.filter((filter) => hasAction(filter, RATIONALE_ACTION))
+    ).toHaveLength(1);
+  });
+
+  it('declares the rationale component Android 14+ requires', () => {
+    const manifest = setHealthConnectManifest(createAndroidManifest());
+
+    const alias = getAliases(manifest).find(
+      (item) => item.$['android:name'] === 'ViewPermissionUsageActivity'
+    );
+
+    expect(alias.$).toEqual({
+      'android:name': 'ViewPermissionUsageActivity',
+      'android:exported': 'true',
+      'android:targetActivity': '.MainActivity',
+      'android:permission': 'android.permission.START_VIEW_PERMISSION_USAGE',
+    });
+    expect(
+      alias['intent-filter'].some((filter) =>
+        hasAction(filter, VIEW_PERMISSION_USAGE_ACTION)
+      )
+    ).toBe(true);
+    expect(alias['intent-filter'][0].category[0].$['android:name']).toBe(
+      'android.intent.category.HEALTH_PERMISSIONS'
+    );
+  });
+
+  it('is idempotent across repeated prebuilds', () => {
+    const once = setHealthConnectManifest(createAndroidManifest());
+    const twice = setHealthConnectManifest(
+      setHealthConnectManifest(createAndroidManifest())
+    );
+
+    expect(twice).toEqual(once);
+  });
+
+  it('does not throw when the main activity has no intent filter yet', () => {
+    const manifest = createAndroidManifest({ mainActivityIntentFilters: null });
+
+    expect(() => setHealthConnectManifest(manifest)).not.toThrow();
+    expect(getMainActivity(manifest)['intent-filter']).toHaveLength(1);
+  });
+
+  it('targets the main activity even when another activity is declared first', () => {
+    const manifest = createAndroidManifest();
+    manifest.manifest.application[0].activity.unshift({
+      '$': { 'android:name': '.SomeOtherActivity' },
+      'intent-filter': [],
+    });
+
+    setHealthConnectManifest(manifest);
+
+    const other = manifest.manifest.application[0].activity.find(
+      (activity) => activity.$['android:name'] === '.SomeOtherActivity'
+    );
+    expect(other['intent-filter']).toHaveLength(0);
+    expect(
+      getMainActivity(manifest)['intent-filter'].some((filter) =>
+        hasAction(filter, RATIONALE_ACTION)
+      )
+    ).toBe(true);
+  });
+
+  it('preserves an unrelated activity alias', () => {
+    const manifest = createAndroidManifest();
+    manifest.manifest.application[0]['activity-alias'] = [
+      {
+        $: {
+          'android:name': 'SomeOtherAlias',
+          'android:targetActivity': '.MainActivity',
+        },
+      },
+    ];
+
+    setHealthConnectManifest(manifest);
+
+    expect(
+      getAliases(manifest).map((alias) => alias.$['android:name'])
+    ).toEqual(['SomeOtherAlias', 'ViewPermissionUsageActivity']);
+  });
+
+  it('leaves existing intent filters on the main activity in place', () => {
+    const manifest = setHealthConnectManifest(createAndroidManifest());
+
+    const filters = getMainActivity(manifest)['intent-filter'];
+    expect(filters[0].action[0].$['android:name']).toBe(
+      'android.intent.action.MAIN'
+    );
+    expect(filters).toHaveLength(2);
+  });
+
+  it('throws a descriptive error when the main activity is missing', () => {
+    const manifest = createAndroidManifest();
+    manifest.manifest.application[0].activity = [];
+
+    expect(() => setHealthConnectManifest(manifest)).toThrow(
+      /missing the required MainActivity/
+    );
+  });
+});
+
+describe('addViewPermissionUsageAlias', () => {
+  it('points at a renamed main activity instead of a hardcoded name', () => {
+    const application = {};
+    const mainActivity = { $: { 'android:name': 'com.example.HomeActivity' } };
+
+    addViewPermissionUsageAlias(application, mainActivity);
+
+    expect(application['activity-alias'][0].$['android:targetActivity']).toBe(
+      'com.example.HomeActivity'
+    );
+  });
+
+  it('repairs an alias left over from an earlier prebuild', () => {
+    const application = {
+      'activity-alias': [
+        {
+          $: {
+            'android:name': 'ViewPermissionUsageActivity',
+            'android:targetActivity': '.OldActivity',
+          },
+        },
+      ],
+    };
+
+    addViewPermissionUsageAlias(application, {
+      $: { 'android:name': '.MainActivity' },
+    });
+
+    expect(application['activity-alias']).toHaveLength(1);
+    expect(application['activity-alias'][0].$['android:targetActivity']).toBe(
+      '.MainActivity'
+    );
+  });
+});

--- a/__tests__/permission-delegate.test.js
+++ b/__tests__/permission-delegate.test.js
@@ -1,0 +1,165 @@
+const { setPermissionDelegate } = require('../app.plugin');
+
+const KOTLIN_IMPORT =
+  'import dev.matinzd.healthconnect.permissions.HealthConnectPermissionDelegate';
+const KOTLIN_CALL =
+  'HealthConnectPermissionDelegate.setPermissionDelegate(this)';
+const JAVA_CALL =
+  'HealthConnectPermissionDelegate.INSTANCE.setPermissionDelegate(this, "com.google.android.apps.healthdata");';
+
+/** MainActivity as `expo prebuild` generates it. */
+const EXPO_MAIN_ACTIVITY = `package com.example
+
+import android.os.Bundle
+import expo.modules.splashscreen.SplashScreenManager
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    setTheme(R.style.AppTheme)
+    // @generated begin expo-splashscreen - expo prebuild (DO NOT MODIFY)
+    SplashScreenManager.registerOnActivity(this)
+    // @generated end expo-splashscreen
+    super.onCreate(null)
+  }
+
+  override fun getMainComponentName(): String = "example"
+}
+`;
+
+/** MainActivity as the bare React Native template generates it: no onCreate. */
+const BARE_MAIN_ACTIVITY = `package com.example
+
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+
+class MainActivity : ReactActivity() {
+  override fun getMainComponentName(): String = "example"
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate =
+    DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+}
+`;
+
+const JAVA_MAIN_ACTIVITY = `package com.example;
+
+import android.os.Bundle;
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  protected String getMainComponentName() {
+    return "example";
+  }
+}
+`;
+
+const JAVA_MAIN_ACTIVITY_WITHOUT_ON_CREATE = `package com.example;
+
+import com.facebook.react.ReactActivity;
+
+public class MainActivity extends ReactActivity {
+  @Override
+  protected String getMainComponentName() {
+    return "example";
+  }
+}
+`;
+
+describe('setPermissionDelegate', () => {
+  it('registers the delegate after super.onCreate in a Kotlin MainActivity', () => {
+    const result = setPermissionDelegate(EXPO_MAIN_ACTIVITY, 'kt');
+
+    expect(result).toContain(KOTLIN_IMPORT);
+    expect(result).toMatch(
+      /super\.onCreate\(null\)\n {4}HealthConnectPermissionDelegate\.setPermissionDelegate\(this\)/
+    );
+  });
+
+  it('leaves the generated splash screen block untouched', () => {
+    const result = setPermissionDelegate(EXPO_MAIN_ACTIVITY, 'kt');
+
+    expect(result).toContain(
+      '// @generated begin expo-splashscreen - expo prebuild (DO NOT MODIFY)\n    SplashScreenManager.registerOnActivity(this)\n    // @generated end expo-splashscreen'
+    );
+  });
+
+  it('adds an onCreate override when the Kotlin MainActivity has none', () => {
+    const result = setPermissionDelegate(BARE_MAIN_ACTIVITY, 'kt');
+
+    expect(result).toContain('import android.os.Bundle');
+    expect(result).toContain(
+      'override fun onCreate(savedInstanceState: Bundle?) {\n    super.onCreate(savedInstanceState)\n    ' +
+        KOTLIN_CALL
+    );
+    // The synthesized override must land inside the class body.
+    expect(result.indexOf('class MainActivity')).toBeLessThan(
+      result.indexOf('override fun onCreate')
+    );
+  });
+
+  it('uses the Java call form in a Java MainActivity', () => {
+    const result = setPermissionDelegate(JAVA_MAIN_ACTIVITY, 'java');
+
+    expect(result).toContain(`${KOTLIN_IMPORT};`);
+    expect(result).toContain(
+      `super.onCreate(savedInstanceState);\n    ${JAVA_CALL}`
+    );
+  });
+
+  it('adds an onCreate override when the Java MainActivity has none', () => {
+    const result = setPermissionDelegate(
+      JAVA_MAIN_ACTIVITY_WITHOUT_ON_CREATE,
+      'java'
+    );
+
+    expect(result).toContain('import android.os.Bundle;');
+    expect(result).toContain(
+      '  @Override\n  protected void onCreate(Bundle savedInstanceState) {\n    super.onCreate(savedInstanceState);\n    ' +
+        JAVA_CALL
+    );
+  });
+
+  it('is idempotent across repeated prebuilds', () => {
+    const once = setPermissionDelegate(EXPO_MAIN_ACTIVITY, 'kt');
+    const twice = setPermissionDelegate(once, 'kt');
+
+    expect(twice).toBe(once);
+  });
+
+  it('does not duplicate a delegate the developer registered by hand', () => {
+    const manual = setPermissionDelegate(BARE_MAIN_ACTIVITY, 'kt');
+
+    expect(setPermissionDelegate(manual, 'kt')).toBe(manual);
+    expect(manual.match(/setPermissionDelegate/g)).toHaveLength(1);
+  });
+
+  it('throws for an unsupported MainActivity language', () => {
+    expect(() => setPermissionDelegate(EXPO_MAIN_ACTIVITY, 'swift')).toThrow(
+      /unsupported MainActivity language/
+    );
+  });
+
+  it('throws when onCreate is overridden without calling super', () => {
+    const contents = BARE_MAIN_ACTIVITY.replace(
+      'override fun getMainComponentName(): String = "example"',
+      'override fun onCreate(savedInstanceState: Bundle?) {}'
+    );
+
+    expect(() => setPermissionDelegate(contents, 'kt')).toThrow(
+      /without calling super\.onCreate/
+    );
+  });
+
+  it('throws when MainActivity has no class declaration to patch', () => {
+    expect(() =>
+      setPermissionDelegate('package com.example\n\nimport foo.Bar\n', 'kt')
+    ).toThrow(/could not find the MainActivity class declaration/);
+  });
+});

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -2,6 +2,7 @@ const {
   AndroidConfig,
   createRunOncePlugin,
   withAndroidManifest,
+  withMainActivity,
 } = require('@expo/config-plugins');
 
 const pkg = require('./package.json');
@@ -91,16 +92,154 @@ function setHealthConnectManifest(androidManifest) {
   return androidManifest;
 }
 
-const withHealthConnect = (config) =>
-  withAndroidManifest(config, (manifestConfig) => {
+const DELEGATE_IMPORT =
+  'dev.matinzd.healthconnect.permissions.HealthConnectPermissionDelegate';
+const BUNDLE_IMPORT = 'android.os.Bundle';
+const HEALTH_CONNECT_PACKAGE = 'com.google.android.apps.healthdata';
+const DELEGATE_CALL = {
+  kt: 'HealthConnectPermissionDelegate.setPermissionDelegate(this)',
+  java: `HealthConnectPermissionDelegate.INSTANCE.setPermissionDelegate(this, "${HEALTH_CONNECT_PACKAGE}");`,
+};
+
+function addImport(contents, importPath, language) {
+  const statement =
+    language === 'java' ? `import ${importPath};` : `import ${importPath}`;
+
+  if (contents.includes(statement)) {
+    return contents;
+  }
+
+  const imports = [...contents.matchAll(/^import .*$/gm)];
+
+  if (imports.length) {
+    const last = imports[imports.length - 1];
+    const insertAt = last.index + last[0].length;
+    return `${contents.slice(0, insertAt)}\n${statement}${contents.slice(
+      insertAt
+    )}`;
+  }
+
+  const packageDeclaration = contents.match(/^package .*$/m);
+
+  if (!packageDeclaration) {
+    throw new Error(
+      'react-native-health-connect: could not find a package declaration in MainActivity.'
+    );
+  }
+
+  const insertAt = packageDeclaration.index + packageDeclaration[0].length;
+  return `${contents.slice(0, insertAt)}\n\n${statement}${contents.slice(
+    insertAt
+  )}`;
+}
+
+/**
+ * Adds an `onCreate` override to a MainActivity that does not declare one,
+ * which is the case for the bare React Native template.
+ */
+function addOnCreateOverride(contents, language) {
+  const body =
+    language === 'java'
+      ? [
+          '  @Override',
+          '  protected void onCreate(Bundle savedInstanceState) {',
+          '    super.onCreate(savedInstanceState);',
+          `    ${DELEGATE_CALL.java}`,
+          '  }',
+        ]
+      : [
+          '  override fun onCreate(savedInstanceState: Bundle?) {',
+          '    super.onCreate(savedInstanceState)',
+          `    ${DELEGATE_CALL.kt}`,
+          '  }',
+        ];
+
+  const classDeclaration = contents.search(/\bclass\s+MainActivity\b/);
+
+  if (classDeclaration === -1) {
+    throw new Error(
+      'react-native-health-connect: could not find the MainActivity class declaration.'
+    );
+  }
+
+  const openingBrace = contents.indexOf('{', classDeclaration);
+
+  if (openingBrace === -1) {
+    throw new Error(
+      'react-native-health-connect: could not find the MainActivity class body.'
+    );
+  }
+
+  const withBundle = addImport(contents, BUNDLE_IMPORT, language);
+  const offset = withBundle.length - contents.length;
+  const insertAt = openingBrace + offset + 1;
+
+  return `${withBundle.slice(0, insertAt)}\n${body.join(
+    '\n'
+  )}\n${withBundle.slice(insertAt)}`;
+}
+
+/**
+ * Registers the permission delegate so `requestPermission()` has an
+ * ActivityResultLauncher to launch. Without it the request throws
+ * `UninitializedPropertyAccessException: lateinit property requestPermission
+ * has not been initialized`.
+ */
+function setPermissionDelegate(contents, language) {
+  if (language !== 'kt' && language !== 'java') {
+    throw new Error(
+      `react-native-health-connect: unsupported MainActivity language "${language}". ` +
+        'Register the permission delegate manually: https://matinzd.github.io/react-native-health-connect/docs/get-started'
+    );
+  }
+
+  // Also covers a delegate the developer registered by hand.
+  if (contents.includes('setPermissionDelegate')) {
+    return contents;
+  }
+
+  const withImport = addImport(contents, DELEGATE_IMPORT, language);
+  const superCall = withImport.match(/^([ \t]*)super\.onCreate\(.*\)[ \t]*;?/m);
+
+  if (!superCall) {
+    if (/\bonCreate\s*\(/.test(withImport)) {
+      throw new Error(
+        'react-native-health-connect: MainActivity overrides onCreate without calling super.onCreate(). ' +
+          'Register the permission delegate manually: https://matinzd.github.io/react-native-health-connect/docs/get-started'
+      );
+    }
+
+    return addOnCreateOverride(withImport, language);
+  }
+
+  const indent = superCall[1];
+  const insertAt = superCall.index + superCall[0].length;
+
+  return `${withImport.slice(0, insertAt)}\n${indent}${
+    DELEGATE_CALL[language]
+  }${withImport.slice(insertAt)}`;
+}
+
+const withHealthConnect = (config) => {
+  const withManifest = withAndroidManifest(config, (manifestConfig) => {
     manifestConfig.modResults = setHealthConnectManifest(
       manifestConfig.modResults
     );
     return manifestConfig;
   });
 
+  return withMainActivity(withManifest, (activityConfig) => {
+    activityConfig.modResults.contents = setPermissionDelegate(
+      activityConfig.modResults.contents,
+      activityConfig.modResults.language
+    );
+    return activityConfig;
+  });
+};
+
 module.exports = createRunOncePlugin(withHealthConnect, pkg.name, pkg.version);
 
 module.exports.setHealthConnectManifest = setHealthConnectManifest;
 module.exports.addRationaleIntentFilter = addRationaleIntentFilter;
 module.exports.addViewPermissionUsageAlias = addViewPermissionUsageAlias;
+module.exports.setPermissionDelegate = setPermissionDelegate;

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,21 +1,106 @@
-const { withAndroidManifest } = require('@expo/config-plugins');
+const {
+  AndroidConfig,
+  createRunOncePlugin,
+  withAndroidManifest,
+} = require('@expo/config-plugins');
 
-const withHealthConnect = function androidManifestPlugin(config) {
-  return withAndroidManifest(config, async (config) => {
-    let androidManifest = config.modResults.manifest;
+const pkg = require('./package.json');
 
-    androidManifest.application[0].activity[0]['intent-filter'].push({
-      action: [
-        {
-          $: {
-            'android:name': 'androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE',
-          },
-        },
-      ],
+const { getMainActivityOrThrow, getMainApplicationOrThrow } =
+  AndroidConfig.Manifest;
+
+const RATIONALE_ACTION = 'androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE';
+const VIEW_PERMISSION_USAGE_ACTION =
+  'android.intent.action.VIEW_PERMISSION_USAGE';
+const HEALTH_PERMISSIONS_CATEGORY =
+  'android.intent.category.HEALTH_PERMISSIONS';
+const VIEW_PERMISSION_USAGE_ALIAS = 'ViewPermissionUsageActivity';
+const START_VIEW_PERMISSION_USAGE_PERMISSION =
+  'android.permission.START_VIEW_PERMISSION_USAGE';
+
+function hasAction(node, action) {
+  return (
+    node.action?.some((item) => item.$?.['android:name'] === action) ?? false
+  );
+}
+
+/**
+ * Declares the rationale intent filter Health Connect uses through Android 13
+ * to open the app when the user taps the privacy policy link.
+ */
+function addRationaleIntentFilter(mainActivity) {
+  const intentFilters = mainActivity['intent-filter'] ?? [];
+
+  if (!intentFilters.some((filter) => hasAction(filter, RATIONALE_ACTION))) {
+    intentFilters.push({
+      action: [{ $: { 'android:name': RATIONALE_ACTION } }],
     });
+  }
 
-    return config;
+  mainActivity['intent-filter'] = intentFilters;
+  return mainActivity;
+}
+
+/**
+ * Declares the rationale component Android 14+ requires. Without it, the
+ * platform silently revokes every `android.permission.health.*` permission:
+ * `requestPermission()` resolves with `[]`, no dialog is shown, and the app
+ * never appears in the Health Connect app permissions list.
+ */
+function addViewPermissionUsageAlias(mainApplication, mainActivity) {
+  const aliases = mainApplication['activity-alias'] ?? [];
+  const existing = aliases.find(
+    (alias) => alias.$?.['android:name'] === VIEW_PERMISSION_USAGE_ALIAS
+  );
+
+  // `targetActivity` is read from the manifest rather than hardcoded, so apps
+  // that rename or fully qualify their main activity still resolve.
+  const targetActivity = mainActivity.$['android:name'];
+
+  if (existing) {
+    existing.$['android:targetActivity'] = targetActivity;
+    return mainApplication;
+  }
+
+  aliases.push({
+    '$': {
+      'android:name': VIEW_PERMISSION_USAGE_ALIAS,
+      'android:exported': 'true',
+      'android:targetActivity': targetActivity,
+      'android:permission': START_VIEW_PERMISSION_USAGE_PERMISSION,
+    },
+    'intent-filter': [
+      {
+        action: [{ $: { 'android:name': VIEW_PERMISSION_USAGE_ACTION } }],
+        category: [{ $: { 'android:name': HEALTH_PERMISSIONS_CATEGORY } }],
+      },
+    ],
   });
-};
 
-module.exports = withHealthConnect;
+  mainApplication['activity-alias'] = aliases;
+  return mainApplication;
+}
+
+function setHealthConnectManifest(androidManifest) {
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+  const mainActivity = getMainActivityOrThrow(androidManifest);
+
+  addRationaleIntentFilter(mainActivity);
+  addViewPermissionUsageAlias(mainApplication, mainActivity);
+
+  return androidManifest;
+}
+
+const withHealthConnect = (config) =>
+  withAndroidManifest(config, (manifestConfig) => {
+    manifestConfig.modResults = setHealthConnectManifest(
+      manifestConfig.modResults
+    );
+    return manifestConfig;
+  });
+
+module.exports = createRunOncePlugin(withHealthConnect, pkg.name, pkg.version);
+
+module.exports.setHealthConnectManifest = setHealthConnectManifest;
+module.exports.addRationaleIntentFilter = addRationaleIntentFilter;
+module.exports.addViewPermissionUsageAlias = addViewPermissionUsageAlias;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^17.4.2",
     "@evilmartians/lefthook": "^1.2.8",
+    "@expo/config-plugins": "^57.0.6",
     "@react-native-community/eslint-config": "^3.0.2",
     "@react-native/babel-preset": "0.81.1",
     "@release-it/conventional-changelog": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,6 +220,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.20.0":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.29.7
+    js-tokens: ^4.0.0
+    picocolors: ^1.1.1
+  checksum: 21b12fe2356e36f6cc3cd8a3721f878bfeea80ce38356979a0518b47b3aafdcc0bd263da75ccc9d51c64d40b1b6df00e768ce2446acb0b7cbec0ae8f905663ad
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.27.2, @babel/compat-data@npm:^7.27.7, @babel/compat-data@npm:^7.28.0":
   version: 7.28.4
   resolution: "@babel/compat-data@npm:7.28.4"
@@ -447,6 +458,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-validator-identifier@npm:7.27.1"
   checksum: 3c7e8391e59d6c85baeefe9afb86432f2ab821c6232b00ea9082a51d3e7e95a2f3fb083d74dc1f49ac82cf238e1d2295dafcb001f7b0fab479f3f56af5eaaa47
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: cc7779e96fe9c9478c96ca4bf04fc338b95b501aa5abe78178307dea282d4a5dc23d443efb12dde8e8c5636d03dd00e443532e6ed7f15fa7977349af1f87ba4d
   languageName: node
   linkType: hard
 
@@ -3168,6 +3186,78 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/config-plugins@npm:^57.0.6":
+  version: 57.0.6
+  resolution: "@expo/config-plugins@npm:57.0.6"
+  dependencies:
+    "@expo/config-types": ^57.0.2
+    "@expo/json-file": ~11.0.1
+    "@expo/plist": ^0.8.1
+    "@expo/require-utils": ^57.0.4
+    "@expo/sdk-runtime-versions": ^1.0.0
+    chalk: ^4.1.2
+    debug: ^4.3.5
+    getenv: ^2.0.0
+    glob: ^13.0.0
+    semver: ^7.5.4
+    slugify: ^1.6.6
+    xcode: ^3.0.1
+    xml2js: 0.6.0
+  checksum: 0d37e96f2988343b82868a3edb895ed559caa0e1c975cfca30fc1eb76a15326cca416f8a0f2880f0c21c6fe71f34bcf1557b7e0febaabac81a9bafb3f7974342
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^57.0.2":
+  version: 57.0.2
+  resolution: "@expo/config-types@npm:57.0.2"
+  checksum: b99831453cca07f353e0f1c94a99c921c6e787298198fd9f201ff2f02f8f983b5c69cded4469206cbdf3a82da34a19a5aa68d0c92545b5dc701c99c0d7c17071
+  languageName: node
+  linkType: hard
+
+"@expo/json-file@npm:~11.0.1":
+  version: 11.0.1
+  resolution: "@expo/json-file@npm:11.0.1"
+  dependencies:
+    "@babel/code-frame": ^7.20.0
+    json5: ^2.2.3
+  checksum: 43c0893503e147163c554f85c49758e9883161474294824d3fce535919b5b1b0c6fc332975a6af9378971fe3ff64d02fe085c6736f2b5cd70d8cec08dd107dae
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@expo/plist@npm:0.8.1"
+  dependencies:
+    "@xmldom/xmldom": ^0.8.8
+    base64-js: ^1.5.1
+    xmlbuilder: ^15.1.1
+  checksum: af58d10ca7406c5dc32947f44005ac70bd1caf0e95dc2c22a99c974be1e124e32d8ee53fee0aa88d81586337772340a646b4f2ce3a28338aec214a1a37facf00
+  languageName: node
+  linkType: hard
+
+"@expo/require-utils@npm:^57.0.4":
+  version: 57.0.4
+  resolution: "@expo/require-utils@npm:57.0.4"
+  dependencies:
+    "@babel/code-frame": ^7.20.0
+    "@babel/core": ^7.25.2
+    "@babel/plugin-transform-modules-commonjs": ^7.24.8
+  peerDependencies:
+    typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: a2c26779eb146fb24931c875d90456e059727b72578ffda883e060f973ac006cf3acabdbfbbfdae149d9c1f54f6dcfe7398d838d1e1f7a827d762c836cbc68ee
+  languageName: node
+  linkType: hard
+
+"@expo/sdk-runtime-versions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@expo/sdk-runtime-versions@npm:1.0.0"
+  checksum: 0942d5a356f590e8dc795761456cc48b3e2d6a38ad2a02d6774efcdc5a70424e05623b4e3e5d2fec0cdc30f40dde05c14391c781607eed3971bf8676518bfd9d
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -5620,6 +5710,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 420f3ba52316163384ce626cda087d06b0eb5888d393b00bbc5f56489bbaccc8633e9b078942ee05facda93fbf813b209a5deb5044f89a6e04373305a0e573c0
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -6361,6 +6465,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -6389,7 +6500,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.44":
+"big-integer@npm:1.6.x, big-integer@npm:^1.6.44":
   version: 1.6.52
   resolution: "big-integer@npm:1.6.52"
   checksum: 6e86885787a20fed96521958ae9086960e4e4b5e74d04f3ef7513d4d0ad631a9f3bde2730fc8aaa4b00419fc865f6ec573e5320234531ef37505da7da192c40b
@@ -6501,6 +6612,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bplist-creator@npm:0.1.1":
+  version: 0.1.1
+  resolution: "bplist-creator@npm:0.1.1"
+  dependencies:
+    stream-buffers: 2.2.x
+  checksum: b0d40d1d1623f1afdbb575cfc8075d742d2c4f0eb458574be809e3857752d1042a39553b3943d2d7f505dde92bcd43e1d7bdac61c9cd44475d696deb79f897ce
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:0.3.2":
+  version: 0.3.2
+  resolution: "bplist-parser@npm:0.3.2"
+  dependencies:
+    big-integer: 1.6.x
+  checksum: fad0f6eb155a9b636b4096a1725ce972a0386490d7d38df7be11a3a5645372446b7c44aacbc6626d24d2c17d8b837765361520ebf2960aeffcaf56765811620e
+  languageName: node
+  linkType: hard
+
 "bplist-parser@npm:^0.2.0":
   version: 0.2.0
   resolution: "bplist-parser@npm:0.2.0"
@@ -6526,6 +6655,15 @@ __metadata:
   dependencies:
     balanced-match: ^1.0.0
   checksum: 01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
+  dependencies:
+    balanced-match: ^4.0.2
+  checksum: acaa9420f52f63c340f405f70e78017a54383696a1138374db4008ea02bef12b6ba5e527b15513147bc474694d81e63c70be992a5efea60d14475219e04fac8d
   languageName: node
   linkType: hard
 
@@ -8163,6 +8301,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: a43826a01cda685ee4cec00fb2d3322eaa90ccadbef60d9287debc2a886be3e835d9199c80070ede75a409ee57828c4c6cd80e4b154f2843f0dc95a570dc0729
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.5":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 4805abd570e601acdca85b6aa3757186084a45cff9b2fa6eee1f3b173caa776b45f478b2a71a572d616d2010cea9211d0ac4a02a610e4c18ac4324bde3760834
   languageName: node
   linkType: hard
 
@@ -10249,6 +10399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"getenv@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "getenv@npm:2.0.0"
+  checksum: d5e4cd001952db17d546c8ae5961b68dd83d0a6c6027cc4c613cbe0f88ca835f661364a7eff32428953e7677af95fb0a35f035c98b661bef2fcabb5d7c711c86
+  languageName: node
+  linkType: hard
+
 "git-raw-commits@npm:^2.0.11, git-raw-commits@npm:^2.0.8":
   version: 2.0.11
   resolution: "git-raw-commits@npm:2.0.11"
@@ -10359,6 +10516,17 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 0bc725de5e4862f9f387fd0f2b274baf16850dcd2714502ccf471ee401803997983e2c05590cb65f9675a3c6f2a58e7a53f9e365704108c6ad3cbf1d60934c4a
+  languageName: node
+  linkType: hard
+
+"glob@npm:^13.0.0":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
+  dependencies:
+    minimatch: ^10.2.2
+    minipass: ^7.1.3
+    path-scurry: ^2.0.2
+  checksum: 1eb421c696c66af3c26e4845dbdd222d3b982ede17448456b49272722d872e9a91741b50e4e827370c57d17a39a69790061f45033523f085c076d8fcc0f69d2b
   languageName: node
   linkType: hard
 
@@ -13160,6 +13328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: ea040bdd8255384d1965c09983e1357ef6eca044747917c2f9db610f3fc773a518ea86bbcffb3b376f793ed61729f240c69cc5593ec89062d64e31c50973f3c0
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -14478,6 +14653,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: ^5.0.5
+  checksum: 000423875fecbc7da1d74bf63c9081363a71291ef2588c376c45647ac004582cb5bc8cc09ef84420b26bfb490f4d0818d328e78569c6228e20d90271283f73ba
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^5.0.1":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
@@ -14578,6 +14762,13 @@ __metadata:
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 2ede17c0bf8fec499be3360fd07f0ec7666189e3907320a9b653f1530cf84af98928c5b12d80bfb75f321833bf2e97785b940540213ebdafe97a5f10327e664d
   languageName: node
   linkType: hard
 
@@ -15593,6 +15784,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: a723afe86e342e19dd1b49ce4f5b64a9a84b1e2e07ffc62f051c11623ecd461b1bf1599eee1ecacfce03dda8b6bb866a5df80c0ded45375d258ff22f631920a7
+  languageName: node
+  linkType: hard
+
 "path-to-regexp@npm:0.1.12":
   version: 0.1.12
   resolution: "path-to-regexp@npm:0.1.12"
@@ -15689,6 +15890,17 @@ __metadata:
   dependencies:
     find-up: ^6.3.0
   checksum: 94298b20a446bfbbd66604474de8a0cdd3b8d251225170970f15d9646f633e056c80520dd5b4c1d1050c9fed8f6a9e5054b141c93806439452efe72e57562c03
+  languageName: node
+  linkType: hard
+
+"plist@npm:^3.0.5":
+  version: 3.1.1
+  resolution: "plist@npm:3.1.1"
+  dependencies:
+    "@xmldom/xmldom": ^0.9.10
+    base64-js: ^1.5.1
+    xmlbuilder: ^15.1.1
+  checksum: 775b2befb6df97b145193e5c241dc63929c58c89673eebc51e06b4b5b3403d15d921140278644ddf6f51a6936d46450d35903a84fc4cba071c46d9c33141817d
   languageName: node
   linkType: hard
 
@@ -17012,6 +17224,7 @@ __metadata:
   dependencies:
     "@commitlint/config-conventional": ^17.4.2
     "@evilmartians/lefthook": ^1.2.8
+    "@expo/config-plugins": ^57.0.6
     "@react-native-community/eslint-config": ^3.0.2
     "@react-native/babel-preset": 0.81.1
     "@release-it/conventional-changelog": ^5.1.1
@@ -17933,6 +18146,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.6.1
+  resolution: "sax@npm:1.6.1"
+  checksum: be78ded08c77db1644a8d32c93266615f51b925c8b6b6f3f689aed10eae57f307f8fbd7bcbf502041903edcfec17ea7d07c7bb4960e076faa92fc6773b621f2a
+  languageName: node
+  linkType: hard
+
 "sax@npm:^1.2.4":
   version: 1.4.1
   resolution: "sax@npm:1.4.1"
@@ -18324,6 +18544,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-plist@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "simple-plist@npm:1.4.0"
+  dependencies:
+    bplist-creator: 0.1.1
+    bplist-parser: 0.3.2
+    plist: ^3.0.5
+  checksum: fa8086f6b781c289f1abad21306481dda4af6373b32a5d998a70e53c2b7218a1d21ebb5ae3e736baae704c21d311d3d39d01d0e6a2387eda01b4020b9ebd909e
+  languageName: node
+  linkType: hard
+
 "sirv@npm:^2.0.3":
   version: 2.0.4
   resolution: "sirv@npm:2.0.4"
@@ -18387,6 +18618,13 @@ __metadata:
     astral-regex: ^1.0.0
     is-fullwidth-code-point: ^2.0.0
   checksum: 4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.6":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: ace83853caefa3a3284c9e66cc85175ec8420ba60fbab75b996c4077d6187a98443f59fffee170f5e0ed448d238fae4653f6afae29b046a1eb029359033e2fb6
   languageName: node
   linkType: hard
 
@@ -18665,6 +18903,13 @@ __metadata:
     es-errors: ^1.3.0
     internal-slot: ^1.1.0
   checksum: be944489d8829fb3bdec1a1cc4a2142c6b6eb317305eeace1ece978d286d6997778afa1ae8cb3bd70e2b274b9aa8c69f93febb1e15b94b1359b11058f9d3c3a1
+  languageName: node
+  linkType: hard
+
+"stream-buffers@npm:2.2.x":
+  version: 2.2.0
+  resolution: "stream-buffers@npm:2.2.0"
+  checksum: 4587d9e8f050d689fb38b4295e73408401b16de8edecc12026c6f4ae92956705ecfd995ae3845d7fa3ebf19502d5754df9143d91447fd881d86e518f43882c1c
   languageName: node
   linkType: hard
 
@@ -19789,6 +20034,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: f5b7b5cc28accac68d5c083fd51cca64896639ebd4cca88c6cfb363801aaa83aa439c86dfc8446ea250a7a98d17afd2ad9e88d9d4958c79a412eccb93bae29de
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
@@ -20388,6 +20642,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xcode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "xcode@npm:3.0.1"
+  dependencies:
+    simple-plist: ^1.1.0
+    uuid: ^7.0.3
+  checksum: 908ff85851f81aec6e36ca24427db092e1cc068f052716e14de5e762196858039efabbe053a1abe8920184622501049e74a93618e8692b982f7604a9847db108
+  languageName: node
+  linkType: hard
+
 "xdg-basedir@npm:^5.0.1, xdg-basedir@npm:^5.1.0":
   version: 5.1.0
   resolution: "xdg-basedir@npm:5.1.0"
@@ -20403,6 +20667,30 @@ __metadata:
   bin:
     xml-js: ./bin/cli.js
   checksum: 24a55479919413687105fc2d8ab05e613ebedb1c1bc12258a108e07cff5ef793779297db854800a4edf0281303ebd1f177bc4a588442f5344e62b3dddda26c2b
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.0":
+  version: 0.6.0
+  resolution: "xml2js@npm:0.6.0"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 437f353fd66d367bf158e9555a0625df9965d944e499728a5c6bc92a54a2763179b144f14b7e1c725040f56bbd22b0fa6cfcb09ec4faf39c45ce01efe631f40b
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:^15.1.1":
+  version: 15.1.1
+  resolution: "xmlbuilder@npm:15.1.1"
+  checksum: 14f7302402e28d1f32823583d121594a9dca36408d40320b33f598bd589ca5163a352d076489c9c64d2dc1da19a790926a07bf4191275330d4de2b0d85bb1843
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Depends on #257 (Android 14+ rationale alias). Together they make the Expo path work without hand-editing generated native files.

Expo users currently have to add this to the generated `MainActivity` by hand:

```kotlin
HealthConnectPermissionDelegate.setPermissionDelegate(this)
```

Every `expo prebuild` overwrites that edit, so `requestPermission()` eventually throws:

```
kotlin.UninitializedPropertyAccessException: lateinit property requestPermission has not been initialized
```

That is the failure mode behind the closed-but-recurring #117 and #71. The plugin now inserts the registration itself.

## Changes

`withMainActivity` inserts the import and the `setPermissionDelegate(this)` call. It handles the MainActivity shapes that appear in the wild:

| Shape | Behaviour |
| --- | --- |
| Kotlin with `onCreate` (Expo / splash-screen) | Inserts after `super.onCreate(...)` |
| Java with `onCreate` | Uses `INSTANCE` and passes the provider package explicitly (Kotlin default args are not visible from Java) |
| Kotlin/Java with no `onCreate` (bare RN template) | Synthesizes the override and the `android.os.Bundle` import |
| Already registered by hand | Left untouched |
| Repeated prebuild | Idempotent |
| `onCreate` that never calls `super` | Throws with a pointer to the manual instructions instead of producing a MainActivity that does not compile |
| Unsupported language | Throws with a pointer to the docs |

Adds `__tests__/permission-delegate.test.js` covering every case above.

## Test plan

- [x] `yarn jest __tests__` — 20 cases green (10 from #257 + 10 new)
- [x] `yarn typecheck`
- [x] `npx expo prebuild -p android --no-clean` on an Expo SDK 57 app → delegate lands after `super.onCreate(null)`, splash-screen generated block untouched, second prebuild is a no-op
- [x] `requestPermission()` shows the Health Connect dialog on an Android 16 emulator (verified together with #257)

Refs #117
Refs #71

Made with [Cursor](https://cursor.com)