### PR TITLE
fix(types): type getChanges upsertions as HealthConnectRecordResult

### DIFF
--- a/docs/docs/api/methods/17-getChanges.md
+++ b/docs/docs/api/methods/17-getChanges.md
@@ -24,7 +24,7 @@ const changeRes = await getChanges({
 })
 
 const {
-  upsertionChanges, // Array<{ record: HealthConnectRecord }>
+  upsertionChanges, // Array<{ record: HealthConnectRecordResult }>
   deletionChanges, // Array<{ recordId: string }>
   nextChangesToken, // string
   changesTokenExpired, // boolean
@@ -32,6 +32,31 @@ const {
 } = changeRes
 ```
 
+# Reading upserted records
+
+Upserted records are serialized exactly like [`readRecords`](./07-readRecords.md) results, **not** like the objects you pass to `insertRecords`. Unit-bearing fields therefore come back as the `*Result` variants — a `Weight` record exposes `inKilograms`, `inGrams`, … rather than `{ value, unit }`:
+
+```json
+{
+  "recordType": "Weight",
+  "weight": {
+    "inGrams": 75000,
+    "inKilograms": 75,
+    "inMilligrams": 75000000,
+    "inMicrograms": 75000000000,
+    "inOunces": 2645.5474378402178,
+    "inPounds": 165.3466966386582
+  }
+}
+```
+
+Narrow on `recordType` to get at the typed record:
+
+```ts
+const weightsInKilograms = upsertionChanges.flatMap(({ record }) =>
+  record.recordType === 'Weight' ? [record.weight.inKilograms] : []
+);
+```
 
 **Note:** `upsertionChanges` includes both updated existing records, and new records since last change token fetch
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -19,6 +19,7 @@ import {
   AggregateResultRecordType,
   DeviceType,
   ExerciseType,
+  getChanges,
   getGrantedPermissions,
   getSdkStatus,
   HealthConnectRecord,
@@ -278,6 +279,8 @@ export default function App() {
   );
   const [isBusy, setIsBusy] = React.useState(false);
 
+  const changesTokenRef = React.useRef<string | undefined>(undefined);
+
   const insertedIdsByTypeRef = React.useRef<Record<DemoRecordType, string[]>>({
     Steps: [],
     Distance: [],
@@ -501,6 +504,36 @@ export default function App() {
     });
   };
 
+  const readChanges = async () => {
+    await runAction('getChanges', async () => {
+      const result = await getChanges({
+        recordTypes: [selectedRecordType],
+        changesToken: changesTokenRef.current,
+      });
+
+      // Keep the token so the next run only reports what changed since now.
+      changesTokenRef.current = result.nextChangesToken;
+
+      // Upserted records are serialized exactly like `readRecords` results, so
+      // unit-bearing fields are the `*Result` variants: a Weight comes back as
+      // `{ inKilograms, inGrams, ... }`, not `{ value, unit }`.
+      const weightsInKilograms = result.upsertionChanges.flatMap(({ record }) =>
+        record.recordType === 'Weight' ? [record.weight.inKilograms] : []
+      );
+
+      const payload = {
+        selectedRecordType,
+        usedToken: result.changesTokenExpired ? 'expired' : 'ok',
+        upsertions: result.upsertionChanges.length,
+        deletions: result.deletionChanges.length,
+        hasMore: result.hasMore,
+        weightsInKilograms,
+        result,
+      };
+      setResultText(formatObject(payload));
+    });
+  };
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar barStyle={'dark-content'} />
@@ -626,6 +659,11 @@ export default function App() {
             <Button
               title="Read latest exercise route"
               onPress={readExerciseRoute}
+            />
+            <View style={styles.buttonGap} />
+            <Button
+              title={`Get changes (${selectedRecordType})`}
+              onPress={readChanges}
             />
           </View>
 

--- a/src/types/changes.types.ts
+++ b/src/types/changes.types.ts
@@ -1,4 +1,5 @@
-import type { RecordType, HealthConnectRecord } from './records.types';
+import type { RecordType } from './records.types';
+import type { HealthConnectRecordResult } from './results.types';
 
 export interface GetChangesRequest {
   changesToken?: string;
@@ -7,7 +8,7 @@ export interface GetChangesRequest {
 }
 
 export interface GetChangesResults {
-  upsertionChanges: Array<{ record: HealthConnectRecord }>;
+  upsertionChanges: Array<{ record: HealthConnectRecordResult }>;
   deletionChanges: Array<{ recordId: string }>;
   nextChangesToken: string;
   changesTokenExpired: boolean;


### PR DESCRIPTION
Fixes #246

## Problem

`getChanges` serializes records via `ReactHealthRecord.parseRecord` (`android/src/main/java/dev/matinzd/healthconnect/HealthConnectManager.kt:229`) — the exact same path `readRecords` uses. The runtime payload therefore uses the read-side shapes (`MassResult`, `EnergyResult`, `LengthResult`, …):

```json
{
  "recordType": "Weight",
  "weight": { "inGrams": 75000, "inKilograms": 75, "inPounds": 165.34 }
}
```

But `GetChangesResults.upsertionChanges[].record` was declared as `HealthConnectRecord`, the **write**-side union, where `weight` is `Mass` (`{ value, unit }`). This mistyped every record carrying a unit-bearing field, not just `Weight`.

## Fix

Point `upsertionChanges[].record` at `HealthConnectRecordResult`. That union keeps `recordType` on each member (unlike `RecordResult<T>`, which strips it), so narrowing by `recordType` continues to work for consumers.

The native behavior is intentional and consistent with `readRecords`, so the returned values are **not** normalized to `Mass` — doing so would break anyone already reading `inKilograms`.

## Note

This is a breaking change at the type level for anyone assigning `change.record.weight` to a `Mass`. Their code was already wrong at runtime; it now fails to compile instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)