### PR TITLE
fix: use LocalDateTime TimeRangeFilter for all groupByPeriod aggregations

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactActiveCaloriesBurnedRecord.kt
@@ -71,7 +71,7 @@ class ReactActiveCaloriesBurnedRecord : ReactHealthRecordImpl<ActiveCaloriesBurn
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBasalMetabolicRateRecord.kt
@@ -67,7 +67,7 @@ class ReactBasalMetabolicRateRecord : ReactHealthRecordImpl<BasalMetabolicRateRe
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactBloodPressureRecord.kt
@@ -73,7 +73,7 @@ class ReactBloodPressureRecord : ReactHealthRecordImpl<BloodPressureRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactCyclingPedalingCadenceRecord.kt
@@ -78,7 +78,7 @@ class ReactCyclingPedalingCadenceRecord : ReactHealthRecordImpl<CyclingPedalingC
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactDistanceRecord.kt
@@ -63,7 +63,7 @@ class ReactDistanceRecord : ReactHealthRecordImpl<DistanceRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactElevationGainedRecord.kt
@@ -61,7 +61,7 @@ class ReactElevationGainedRecord : ReactHealthRecordImpl<ElevationGainedRecord> 
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactExerciseSessionRecord.kt
@@ -149,7 +149,7 @@ class ReactExerciseSessionRecord : ReactHealthRecordImpl<ExerciseSessionRecord> 
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactFloorsClimbedRecord.kt
@@ -61,7 +61,7 @@ class ReactFloorsClimbedRecord : ReactHealthRecordImpl<FloorsClimbedRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeartRateRecord.kt
@@ -79,7 +79,7 @@ class ReactHeartRateRecord : ReactHealthRecordImpl<HeartRateRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHeightRecord.kt
@@ -60,7 +60,7 @@ class ReactHeightRecord : ReactHealthRecordImpl<HeightRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactHydrationRecord.kt
@@ -61,7 +61,7 @@ class ReactHydrationRecord : ReactHealthRecordImpl<HydrationRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactNutritionRecord.kt
@@ -189,7 +189,7 @@ class ReactNutritionRecord : ReactHealthRecordImpl<NutritionRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactPowerRecord.kt
@@ -78,7 +78,7 @@ class ReactPowerRecord : ReactHealthRecordImpl<PowerRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactRestingHeartRateRecord.kt
@@ -62,7 +62,7 @@ class ReactRestingHeartRateRecord : ReactHealthRecordImpl<RestingHeartRateRecord
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSleepSessionRecord.kt
@@ -79,7 +79,7 @@ class ReactSleepSessionRecord : ReactHealthRecordImpl<SleepSessionRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactSpeedRecord.kt
@@ -78,7 +78,7 @@ class ReactSpeedRecord : ReactHealthRecordImpl<SpeedRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt
@@ -78,7 +78,7 @@ class ReactStepsCadenceRecord : ReactHealthRecordImpl<StepsCadenceRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
@@ -61,7 +61,7 @@ class ReactTotalCaloriesBurnedRecord : ReactHealthRecordImpl<TotalCaloriesBurned
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWeightRecord.kt
@@ -61,7 +61,7 @@ class ReactWeightRecord : ReactHealthRecordImpl<WeightRecord> {
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )

--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactWheelchairPushesRecord.kt
@@ -61,7 +61,7 @@ class ReactWheelchairPushesRecord : ReactHealthRecordImpl<WheelchairPushesRecord
   override fun getAggregateGroupByPeriodRequest(record: ReadableMap): AggregateGroupByPeriodRequest {
     return AggregateGroupByPeriodRequest(
       metrics = aggregateMetrics,
-      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
       timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
     )


### PR DESCRIPTION
## Problem

`aggregateGroupByPeriod` fails for every record type except `StepsRecord`:

```
java.lang.IllegalArgumentException: Either use TimeRangeFilter with LocalDateTime or AggregateGroupByDurationRequest
```

Health Connect requires a **LocalDateTime**-based `TimeRangeFilter` for `AggregateGroupByPeriodRequest`. #248 introduced `getTimeRangeFilterLocal` but only applied it to `ReactStepsRecord`; the other record implementations still built `Instant`-based filters.

## Fix

Switch `getAggregateGroupByPeriodRequest` to `getTimeRangeFilterLocal("timeRangeFilter")` in the remaining 20 record implementations. Instants coming from JS are converted using the device's default zone, so the public JS API is unchanged.

`getAggregateGroupByDurationRequest` is left on `Instant` filters, which Duration grouping accepts.

## Related issues

- #194 aggregateGroupByPeriod returns error on Android 13 & under
- #174 `Duration must be set with physical times` error for aggregateGroupByPeriod on Android 13 and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)