### PR TITLE
docs: add CLAUDE.md index and .claude/docs notes

### DIFF
--- a/.claude/docs/adding-a-record-type.md
+++ b/.claude/docs/adding-a-record-type.md
@@ -1,0 +1,36 @@
+# Adding or changing a record type
+
+The work is spread across parallel registries on both sides of the bridge. Missing one fails at
+runtime, not at compile time.
+
+Using `StepsCadence` as the reference implementation:
+
+## Kotlin
+
+1. `android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsCadenceRecord.kt` —
+   implement `ReactHealthRecordImpl<StepsCadenceRecord>`. If the type does not support
+   aggregation, throw `AggregationNotSupported()` from the aggregate methods (existing records
+   show the convention).
+2. Register in **all three** maps in `utils/HealthConnectUtils.kt`:
+   - `reactRecordTypeToClassMap` — `"StepsCadence" to StepsCadenceRecord::class`
+   - `reactRecordTypeToReactClassMap` — `"StepsCadence" to ReactStepsCadenceRecord::class.java`
+   - `healthConnectClassToReactClassMap` — `StepsCadenceRecord::class.java to ReactStepsCadenceRecord::class.java`
+
+   The third is only exercised by `getChanges`, so omitting it passes every read/write test and
+   breaks the change feed.
+
+## TypeScript
+
+3. `src/types/records.types.ts` — the record interface with its `recordType` literal, added to the
+   `HealthConnectRecord` union.
+4. `src/types/results.types.ts` — the `...RecordResult` interface and its union entry.
+5. `src/types/aggregate.types.ts` — the aggregate result interface and union entry, if aggregable.
+
+Reusable unit helpers (`massToJsMap`, energy, power, temperature, velocity, length …) already
+exist in `utils/HealthConnectUtils.kt`; the corresponding `Invalid*` exceptions are in
+`utils/ExceptionsUtils.kt`.
+
+## Verify
+
+`yarn typecheck` catches the TS side. The Kotlin registries are not type-checked against each
+other — exercise the type through the example app (insert → read → aggregate → `getChanges`).

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -1,0 +1,60 @@
+# Architecture
+
+Android-only React Native library wrapping `androidx.health.connect:connect-client`. There is no
+iOS implementation — `src/index.tsx` swaps in a proxy that throws
+`PLATFORM_NOT_SUPPORTED_ERROR` on non-Android platforms.
+
+## Layers
+
+```
+src/index.tsx            public JS API (thin; mostly re-exports the native module)
+src/NativeHealthConnect.ts  TurboModule spec — codegen source of truth (codegenConfig.jsSrcsDir = src)
+src/types/               all record / aggregate / result / changes typings
+   ↓ bridge
+android/src/{newarch,oldarch}/HealthConnectSpec.kt   two hand-written base classes, one per arch
+android/.../HealthConnectModule.kt   @ReactMethod surface; every method just delegates
+android/.../HealthConnectManager.kt  all real logic: client lifecycle, coroutines, promises
+android/.../records/                 per-record-type adapters
+android/.../permissions/             permission + exercise route dialogs
+android/.../utils/                   registries, unit conversion, exception → error-code mapping
+```
+
+`HealthConnectModule` is deliberately empty of logic — it exists to satisfy the codegen'd spec.
+Put behaviour in `HealthConnectManager`.
+
+The old/new architecture split lives in `android/build.gradle` via `isNewArchitectureEnabled()`,
+which picks `src/oldarch` or `src/newarch` as an extra source dir. Both files declare the same
+abstract methods; if you add a native method you must update **both**, plus
+`src/NativeHealthConnect.ts`.
+
+## Record adapter pattern
+
+Every Health Connect record type has a `ReactXxxRecord` class in `android/.../records/`
+implementing `ReactHealthRecordImpl<T : Record>` — parse-from-JS, parse-to-JS, and the three
+aggregate request/result shapes.
+
+Dispatch is by three parallel maps in `utils/HealthConnectUtils.kt`:
+
+| Map | Purpose |
+| --- | --- |
+| `reactRecordTypeToClassMap` | `"Steps"` → `StepsRecord::class` (permissions, deletes, reads) |
+| `reactRecordTypeToReactClassMap` | `"Steps"` → `ReactStepsRecord::class.java` |
+| `healthConnectClassToReactClassMap` | `StepsRecord::class.java` → `ReactStepsRecord::class.java` (used when parsing change feeds, where only the SDK class is known) |
+
+`ReactHealthRecord` reflectively instantiates the adapter from those maps. A record type missing
+from any one of them fails at runtime, not compile time — see
+[adding-a-record-type.md](adding-a-record-type.md).
+
+## Error handling
+
+`Promise.rejectWithException` in `utils/ExceptionsUtils.kt` maps exception types to stable string
+error codes consumed by `src/errors.ts`. New library-specific exceptions go in that file **and**
+in the `when` block, otherwise they surface as `UNKNOWN_ERROR`.
+
+## Permissions
+
+Permission and exercise-route dialogs need an `ActivityResultRegistry`, which a native module does
+not have. The library hosts its own transparent activity to get one — no `MainActivity` changes
+required from consumers. See
+[../plans/activity-result-without-main-activity.md](../plans/activity-result-without-main-activity.md); it also
+documents the approach that looks obvious but crashes on Android 14+.

--- a/.claude/docs/expo-and-linking.md
+++ b/.claude/docs/expo-and-linking.md
@@ -1,0 +1,38 @@
+# Expo integration and autolinking invariants
+
+As of v4 the Expo integration ships **inside** this package; the separate `expo-health-connect`
+is deprecated. The library has **no Expo native module** — the only Expo-specific artifact is the
+config plugin.
+
+| Piece | Role |
+| --- | --- |
+| `app.plugin.js` | Config plugin. Patches the consumer's `AndroidManifest.xml` with the `androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE` intent-filter (≤ Android 13) and a `ViewPermissionUsageActivity` activity-alias guarded by `START_VIEW_PERMISSION_USAGE` (Android 14+). Wrapped in `createRunOncePlugin`; both patches are idempotent — running prebuild twice must not duplicate them. |
+| `android/` | Plain React Native library project. Expo autolinking picks it up by convention, same as any other RN package. |
+
+There used to be an `android-expo/` Expo module plus an `expo-module.config.json`; it existed only
+to register the permission delegate from a `ReactActivityLifecycleListener`. That requirement is
+gone (see [../plans/activity-result-without-main-activity.md](../plans/activity-result-without-main-activity.md)),
+so both were removed. Don't reintroduce an Expo module without a reason that genuinely needs
+`expo-modules-core`.
+
+## The invariants CI enforces
+
+Both directions matter and each has a dedicated job in `.github/workflows/ci.yml`:
+
+- **`expo-prebuild`** — in a managed Expo app, the config plugin must patch the manifest and
+  `:react-native-health-connect` must be linked. Verified via `./gradlew projects`, not by grepping
+  `settings.gradle` (`useExpoModules()` includes projects at configuration time, so there is
+  nothing to grep), and then by `strings` over the APK's dex to prove packaging rather than mere
+  configuration.
+- **`bare-example`** — a bare React Native app must link the library and pull in **nothing** from
+  expo. Bare projects have no `expo-modules-core`, so any expo dependency creeping into `android/`
+  breaks every non-Expo consumer.
+
+## example-expo is not a workspace
+
+`example-expo/` is its own Yarn project. Yarn refuses to materialise a `link:`/`portal:` symlink
+whose target is an *ancestor* directory, and Expo autolinking needs a real `node_modules` entry to
+discover the library — unlike React Native CLI autolinking, it does not read
+`react-native.config.js`. Its `postinstall` creates that symlink. Consequence: a root `yarn
+install` does not reach it; run `yarn install` inside `example-expo/` separately. Its `android/`
+directory is gitignored — regenerate with `npx expo prebuild --clean --platform android`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+`react-native-health-connect` — an Android-only React Native wrapper around
+`androidx.health.connect:connect-client`.
+
+## Detailed docs
+
+Read the relevant one before working in that area; they hold the context that requires reading
+many files to reconstruct.
+
+| Doc | When to read it |
+| --- | --- |
+| [.claude/docs/architecture.md](.claude/docs/architecture.md) | Any native change. Layering, the old/new-arch spec split, the record adapter pattern, error-code mapping. |
+| [.claude/docs/adding-a-record-type.md](.claude/docs/adding-a-record-type.md) | Adding or modifying a Health Connect record type — a pattern repeated across three Kotlin registries and three TS unions. |
+| [.claude/plans/activity-result-without-main-activity.md](.claude/plans/activity-result-without-main-activity.md) | Anything touching permissions or the exercise-route dialog. Includes the approach that looks correct but crashes on Android 14+. |
+| [.claude/docs/expo-and-linking.md](.claude/docs/expo-and-linking.md) | Touching `app.plugin.js`, `example-expo/`, or the CI linking jobs. |
+
+## Commands
+
+```sh
+yarn                        # root install (workspaces: example, docs — NOT example-expo)
+yarn lint                   # eslint ./src   (--fix to format)
+yarn typecheck              # tsc --noEmit
+yarn test                   # jest
+yarn test -t "<name>"       # single test by name
+yarn prepack                # build the package with react-native-builder-bob
+
+yarn example start          # Metro
+yarn example android        # bare example
+ORG_GRADLE_PROJECT_newArchEnabled=true yarn example android   # new arch
+yarn clean                  # remove build dirs (required when switching architecture)
+```
+
+Expo example (separate project, see the Expo doc):
+
+```sh
+cd example-expo && yarn install && npx expo prebuild --clean --platform android && npx expo run:android
+```
+
+Kotlin-only iteration is faster through the example's Gradle wrapper:
+
+```sh
+cd example/android && ./gradlew :react-native-health-connect:compileDebugKotlin
+```
+
+## Conventions
+
+- Conventional commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`) — enforced by a
+  commitlint pre-commit hook, and the changelog/release is generated from them.
+- Kotlin in this repo uses 2-space indent, matching the TS side.
+- Adding a native method means touching four files: `src/NativeHealthConnect.ts`,
+  `android/src/oldarch/HealthConnectSpec.kt`, `android/src/newarch/HealthConnectSpec.kt`, and
+  `HealthConnectModule.kt` (which should only delegate to `HealthConnectManager`).
+- User-facing docs live in two places that drift easily: `README.md` and the Docusaurus site under
+  `docs/docs/`. Update both.


### PR DESCRIPTION
Adds a `CLAUDE.md` that is deliberately just an index, with the substance in `.claude/docs/`:

- `architecture.md` — layering, the old/new-arch spec split, the record adapter pattern and its three dispatch maps, error-code mapping.
- `adding-a-record-type.md` — the six places a record type must be registered, including the map only `getChanges` exercises, which is easy to miss.
- `expo-and-linking.md` — the config plugin, the two opposing autolinking invariants CI enforces, and why `example-expo` is not a workspace.

No code changes.

> [!NOTE]
> Depends on #266. These notes describe the post-#266 state — they say the library has no Expo native module and link to `.claude/plans/activity-result-without-main-activity.md`, both of which land in that PR. Merge #266 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)