### PR TITLE
chore(internal): replace deprecated TurboReactPackage and ReactModuleInfo APIs

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/HealthConnectPackage.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/HealthConnectPackage.kt
@@ -1,13 +1,13 @@
 package dev.matinzd.healthconnect
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.module.model.ReactModuleInfo
 import java.util.HashMap
 
-class HealthConnectPackage : TurboReactPackage() {
+class HealthConnectPackage : BaseReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     return if (name == HealthConnectModule.NAME) {
       HealthConnectModule(reactContext)
@@ -23,11 +23,10 @@ class HealthConnectPackage : TurboReactPackage() {
       moduleInfos[HealthConnectModule.NAME] = ReactModuleInfo(
         HealthConnectModule.NAME,
         HealthConnectModule.NAME,
-        false,  // canOverrideExistingModule
-        false,  // needsEagerInit
-        true,  // hasConstants
-        false,  // isCxxModule
-        isTurboModule // isTurboModule
+        canOverrideExistingModule = false,
+        needsEagerInit = false,
+        isCxxModule = false,
+        isTurboModule = isTurboModule
       )
       moduleInfos
     }


### PR DESCRIPTION
## Summary

Drops two deprecated React Native Android APIs from `HealthConnectPackage`, since the RN versions that are needed are well within the support window of RN itself.

- `TurboReactPackage` → `BaseReactPackage`
- `ReactModuleInfo`: removed the ignored `hasConstants` argument, named the remaining flags

## Why

Checked against the React Native tags:

| API | Status |
| --- | --- |
| `BaseReactPackage` | Added in **0.74.0**; `TurboReactPackage` became an empty subclass marked `@DeprecatedInNewArchitecture` in the same release, and a hard Kotlin `@Deprecated` (with `ReplaceWith`) in **0.77.0**. |
| `ReactModuleInfo(name, className, canOverrideExistingModule, needsEagerInit, isCxxModule, isTurboModule)` | 6-arg overload added in **0.73.0**; the 7-arg one is deprecated and its `hasConstants` parameter has been ignored ever since (`hasConstants()` just returns `true`). |

Both deprecated APIs still exist on `main` upstream, so this is a warning cleanup rather than a break-fix.

## Minimum React Native version

This raises the effective floor for the Android build to **RN 0.75**:

- `BaseReactPackage` needs 0.74+
- the named-argument call style needs 0.75+, where `ReactModuleInfo` was converted to Kotlin — Kotlin does not allow named arguments when calling a Java constructor, so on 0.73/0.74 this fails with *"Named arguments are not allowed for non-Kotlin functions"*

## Test plan

- `./gradlew :react-native-health-connect:compileDebugKotlin` from `example/android` — `BUILD SUCCESSFUL`, no Kotlin deprecation warnings
