### PR TITLE
fix: expose READ_HEALTH_DATA_HISTORY in getGrantedPermissions

### DIFF
--- a/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
+++ b/android/src/main/java/dev/matinzd/healthconnect/permissions/PermissionUtils.kt
@@ -62,6 +62,10 @@ class PermissionUtils {
           pushMap(ReactPermission(AccessType.WRITE, "ExerciseRoute").toReadableMap())
         }
 
+        if (grantedPermissions.contains(HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY)) {
+          pushMap(ReactPermission(AccessType.READ, "ReadHealthDataHistory").toReadableMap())
+        }
+
         if (grantedPermissions.contains(HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND)
         ) {
           pushMap(ReactPermission(AccessType.READ, "BackgroundAccessPermission").toReadableMap())

--- a/docs/docs/api/methods/18-readHealthDataHistoryPermission.md
+++ b/docs/docs/api/methods/18-readHealthDataHistoryPermission.md
@@ -1,0 +1,67 @@
+---
+title: Read Health Data History Permission
+---
+
+# Read Health Data History Permission
+
+Health Connect provides a special permission that allows your app to read health data recorded
+before it was granted access, rather than only data written from the grant date forward. This is
+useful for apps that want to show historical trends the first time a user connects their data.
+
+## Setup
+
+### 1. Add the permission to your AndroidManifest.xml
+
+First, you need to declare the health data history permission in your app's `AndroidManifest.xml` file:
+
+```xml
+<uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
+```
+
+### 2. Request the permission in your app
+
+Then, include the health data history permission in your permission request:
+
+```ts
+import { requestPermission } from 'react-native-health-connect';
+
+const requestPermissions = () => {
+  requestPermission([
+    {
+      accessType: 'read',
+      recordType: 'ReadHealthDataHistory',
+    },
+    // Other permissions...
+  ]).then((permissions) => {
+    console.log('Granted permissions ', { permissions });
+  });
+};
+```
+
+## Android Implementation
+
+Under the hood, this permission maps to `HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY` in the Android Health Connect API. Without it, reads are limited to records created after your app was first granted access.
+
+## Checking for Health Data History Access
+
+You can check if your app has been granted health data history permission using the `getGrantedPermissions` method:
+
+```ts
+import { getGrantedPermissions } from 'react-native-health-connect';
+
+const checkHistoryAccess = async () => {
+  const permissions = await getGrantedPermissions();
+  const hasHistoryAccess = permissions.some(
+    (permission) =>
+      permission.accessType === 'read' &&
+      permission.recordType === 'ReadHealthDataHistory'
+  );
+
+  console.log('Has health data history access:', hasHistoryAccess);
+};
+```
+
+## Important Notes
+
+- This permission is only available on Android devices with Health Connect support
+- Make sure to explain to users why your app needs access to their historical health data

--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -27,3 +27,4 @@ title: Overview
 | **Permission Type**        | **Description**                                                                                                                                                                                                                           |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | BackgroundAccessPermission | Allows your app to read health data in the background, even when your app is not in the foreground. |
+| ReadHealthDataHistory | Allows your app to read health data recorded before it was granted access, instead of only data written from the grant date forward. |

--- a/docs/docs/permissions.md
+++ b/docs/docs/permissions.md
@@ -202,6 +202,33 @@ Under the hood, this maps to `HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BA
 
 See the [Background Access Permission](./api/methods/17-backgroundAccessPermission.md) documentation for more details.
 
+### Read Health Data History Permission
+
+This permission allows your app to read health data recorded before it was granted access, instead of only data written from the grant date forward.
+
+First, add the health data history permission to your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
+```
+
+Then, request the permission in your app:
+
+```ts
+// Request health data history permission
+requestPermission([
+  {
+    accessType: 'read',
+    recordType: 'ReadHealthDataHistory',
+  },
+  // Other permissions...
+]);
+```
+
+Under the hood, this maps to `HealthPermission.PERMISSION_READ_HEALTH_DATA_HISTORY` in the Android Health Connect API.
+
+See the [Read Health Data History Permission](./api/methods/18-readHealthDataHistoryPermission.md) documentation for more details.
+
 ### Exercise Route Permission
 
 This special permission is required to write exercise routes:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,7 +132,12 @@ export function requestExerciseRoute(recordId: string): Promise<Location[]> {
  * @returns A promise that resolves to an array of granted permissions
  */
 export function getGrantedPermissions(): Promise<
-  (Permission | WriteExerciseRoutePermission | BackgroundAccessPermission)[]
+  (
+    | Permission
+    | WriteExerciseRoutePermission
+    | ReadHealthDataHistoryPermission
+    | BackgroundAccessPermission
+  )[]
 > {
   return HealthConnect.getGrantedPermissions();
 }


### PR DESCRIPTION
It's possible with `react-native-health-connect` to request `READ_HEALTH_DATA_HISTORY	`, but as far as I could tell it was not possible to determine if that permission had been granted or not. `getGrantedPermissions` did not return the permission status, but I noticed that there was a special case for `PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND` in that function. It seemed like a good place to handle `READ_HEALTH_DATA_HISTORY` the same way.

I also replicated the documentation for `READ_HEALTH_DATA_IN_BACKGROUND` too, since the user-facing permission flow for this permission is included in the same card as `READ_HEALTH_DATA_HISTORY`.

Happy to make any tweaks necessary to help get this merged. Just let me know!